### PR TITLE
fix namespaces already exists error when registtering cluster with pu…

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -81,7 +81,7 @@ Step 2:  Create karmada kubeconfig secret
 Step 3: Create karmada agent
 (In member kubernetes)~#  MEMBER_CLUSTER_NAME="demo"
 (In member kubernetes)~#  sed -i "s/{member_cluster_name}/${MEMBER_CLUSTER_NAME}/g" karmada-agent.yaml
-(In member kubernetes)~#  kubectl create -f karmada-agent.yaml
+(In member kubernetes)~#  kubectl apply -f karmada-agent.yaml
                                                                                                                                                                              
 Step 4: Show members of karmada                                                                                                                                              
 (In karmada)~# kubectl  --kubeconfig /etc/karmada/karmada-apiserver.config get clusters


### PR DESCRIPTION
…ll mode

Signed-off-by: bruce <zhangyongxi_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
when registerring cluster with 'Pull' mode, a namespaces already exists error will be found.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
none