### PR TITLE
Fix broken links for v1.3.0

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/administrator/upgrading/v0.10-v1.0.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/administrator/upgrading/v0.10-v1.0.md
@@ -222,5 +222,5 @@ rules:
 Since the `discovery.k8s.io/v1beta1` of `EndpointSlices` has been deprecated in favor of `discovery.k8s.io/v1`, in
 [Kubernetes v1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md), Karmada adopt 
 this change at release v1.0.0.
-Now the [MCS](./multi-cluster-service.md) feature requires 
+Now the [MCS](../../userguide/service/multi-cluster-service.md) feature requires 
 member cluster version no less than v1.21.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
When looking at the building logs, I can see the warning as follows:
```
5:03:39 PM: Exhaustive list of all broken links found:
5:03:39 PM: 
5:03:39 PM: - On source page path = /zh/docs/administrator/upgrading/v0.10-v1.0:
5:03:39 PM:    -> linking to ./multi-cluster-service.md (resolved as: /zh/docs/administrator/upgrading/multi-cluster-service.md)
```
This page is not exist:
https://karmada.io/zh/docs/administrator/upgrading/multi-cluster-service.md

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

@Arhell @rgrupesh I remember Docusaurus can deny broken links during the building phase, I think this feature was disabled by #31, I guess it's time to get the feature back, how do you think? 
```
5:03:39 PM: [WARNING] Docusaurus found broken links!
5:03:39 PM: 
5:03:39 PM: Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.
```

