### PR TITLE
update .gitignore to remove default generate  directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .docusaurus
 .hugo_build.lock
 .idea
+build


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind cleanup

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

add build cachedir to .gitignore

**Special notes for your reviewer**:

Ignore the files generated by default build to prevent contributors from misoperations causing build files to be carried in PR; this is very friendly to new users.

