### PR TITLE
make doc prettier in performance-test-setup-for-karmada.md

### DIFF
--- a/docs/developers/performance-test-setup-for-karmada.md
+++ b/docs/developers/performance-test-setup-for-karmada.md
@@ -4,7 +4,10 @@ title: Performance Test Setup for Karmada
 
 ## Abstract
 
-As Karmada is being implemented in more and more enterprises and organizations, scalability and scale of Karmada is gradually becoming new concerns for the community. In this article, we will introduce how to conduct large-scale testing for Karmada and how to monitor metrics from Karmada control plane.
+As Karmada is being implemented in more and more enterprises and organizations,
+scalability and scale of Karmada is gradually becoming new concerns for the community.
+In this article, we will introduce how to conduct large-scale testing for Karmada and
+how to monitor metrics from Karmada control plane.
 
 ## Build large scale environment
 
@@ -12,7 +15,9 @@ As Karmada is being implemented in more and more enterprises and organizations, 
 
 #### Why kind
 
-[Kind](https://sigs.k8s.io/kind) is a tool for running local Kubernetes clusters using Docker containers. Kind was primarily designed for testing Kubernetes itself, so it play a good role in simulating member clusters.
+[Kind](https://sigs.k8s.io/kind) is a tool for running local Kubernetes clusters
+using Docker containers. Kind was primarily designed for testing Kubernetes itself,
+so it play a good role in simulating member clusters.
 
 #### Usage
 
@@ -26,34 +31,37 @@ for ((i=1; i<=10; i ++)); do
 done;
 ```
 
-
-
 ### Simulate a large number of fake nodes using fake-kubelet
 
 #### Why fake-kubelet
 
 ##### Compare to Kubemark
 
-**Kubemark** is directly implemented with the code of kubelet, replacing the runtime part, except that it does not actually start the container, other behaviors are exactly the same as kubelet, mainly used for Kubernetes own e2e test, simulating a large number of nodes and pods will **occupy the same memory as the real scene**.
+**Kubemark** is directly implemented with the code of kubelet, replacing the runtime
+part, except that it does not actually start the container, other behaviors are exactly
+the same as kubelet, mainly used for Kubernetes own e2e test, simulating a large number
+of nodes and pods will **occupy the same memory as the real scene**.
 
-**Fake-kubelet** is a tool used to simulate any number of nodes and maintain pods on those nodes. It only does the minimum work of maintaining nodes and pods, so that it is very suitable for simulating a large number of nodes and pods for pressure testing on the control plane.
+**Fake-kubelet** is a tool used to simulate any number of nodes and maintain pods on
+those nodes. It only does the minimum work of maintaining nodes and pods, so that it
+is very suitable for simulating a large number of nodes and pods for pressure testing
+on the control plane.
 
 #### Usage
 
 Deploy the fake-kubelet:
 
-> Note:  Set container ENV `GENERATE_REPLICAS` in fake-kubelet deployment to set node replicas you want to create
+> Note: Set container ENV `GENERATE_REPLICAS` in fake-kubelet deployment to set node replicas you want to create
 
 ```shell
 export GENERATE_REPLICAS=your_replicas
 curl https://raw.githubusercontent.com/wzshiming/fake-kubelet/master/deploy.yaml > fakekubelet.yml
 # GENERATE_REPLICAS default value is 5000
-sed -i "s/5000/$GENERATE_REPLICAS/g" fakekubelet.yml 
+sed -i "s/5000/$GENERATE_REPLICAS/g" fakekubelet.yml
 kubectl apply -f fakekubelet.yml
 ```
 
-
-`kubectl get node` You will find fake nodes.
+With `kubectl get node`, you will find fake nodes.
 
 ```shell
 > kubectl get node -o wide
@@ -104,7 +112,7 @@ spec:
 EOF
 ```
 
-`kubectl get pod` You will find that it has been started, although the image does not exist.
+With `kubectl get pod`, you will find that it has been started, although the image does not exist.
 
 ```shell
 > kubectl get pod -o wide
@@ -115,13 +123,16 @@ fake-pod-78884479b7-dqjtn   1/1     Running   0          6s    10.0.0.15   fake-
 fake-pod-78884479b7-h2fv6   1/1     Running   0          6s    10.0.0.31   fake-0   <none>           <none>
 ```
 
-
-
 ## Distribute resources using CLusterLoader2
 
 ### ClusterLoader2
 
-[ClusterLoader2](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2) is an open source Kubernetes cluster testing tool. It tests against Kubernetes-defined SLIs/SLOs metrics to verify that clusters meet various quality of service standards. ClusterLoader2 is a tool oriented single cluster, it is complex to test karmada control plane meanwhile distribute resouces to member clusters. Therefore, we just use the ClusterLoader2 to distribute resources to clusters managed by karmada.
+[ClusterLoader2](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2)
+is an open source Kubernetes cluster testing tool. It tests against Kubernetes-defined
+SLIs/SLOs metrics to verify that clusters meet various quality of service standards.
+ClusterLoader2 is a tool oriented single cluster, it is complex to test karmada control
+plane meanwhile distribute resouces to member clusters. Therefore, we just use the
+ClusterLoader2 to distribute resources to clusters managed by karmada.
 
 ### Prepare a simple config
 
@@ -131,14 +142,14 @@ Let's prepare our config (config.yaml) to distribute resources. This config will
 
 - Create 20 deployments with 1000 pods inside that namespace
 
-
 We will create file `config.yaml` that describes this test. First we need to start with defining test name:
 
 ```yaml
 name: test
 ```
 
-ClusterLoader2 will create namespaces automatically, but we need to specify how many namespaces we want and whether delete the namespaces after distributing resources:
+ClusterLoader2 will create namespaces automatically, but we need to specify how many
+namespaces we want and whether delete the namespaces after distributing resources:
 
 ```yaml
 namespace:
@@ -146,7 +157,11 @@ namespace:
   deleteAutomanagedNamespaces: false
 ```
 
-Next, we need to specify TuningSets. TuningSet describes how actions are executed. The qps means 1/qps s per action interval. In order to distribute resources slowly to relieve the pressure on the apiserver, the qps of Uniformtinyqps is set to 0.1, which means that after distributing a deployment, we wait 10s before continuing to distribute the next deployment.
+Next, we need to specify TuningSets. TuningSet describes how actions are executed.
+The qps means 1/qps s per action interval. In order to distribute resources slowly
+to relieve the pressure on the apiserver, the qps of Uniformtinyqps is set to 0.1,
+which means that after distributing a deployment, we wait 10s before continuing to
+distribute the next deployment.
 
 ```yaml
 tuningSets:
@@ -158,7 +173,12 @@ tuningSets:
     qps: 1
 ```
 
-Finally, we will create a phase that creates deployment and propagation policy. We need to specify in which namespaces we want the deployment and propagation policy to be created, how many of these deployments per namespace. Also, we will need to specify template for our deployment and propagation policy , which we will do later. For now, let's assume that this template allows us to specify numbers of replicas in deployment and propagation policy.
+Finally, we will create a phase that creates deployment and propagation policy.
+We need to specify in which namespaces we want the deployment and propagation
+policy to be created, how many of these deployments per namespace. Also, we will
+need to specify template for our deployment and propagation policy, which we will
+do later. For now, let's assume that this template allows us to specify numbers
+of replicas in deployment and propagation policy.
 
 ```yaml
 steps:
@@ -183,7 +203,7 @@ steps:
       objectTemplatePath: "policy.yaml"
       templateFillMap:
         Replicas: 1
-        
+
 ```
 
 The whole `config.yaml` will look like this:
@@ -194,7 +214,7 @@ name: test
 namespace:
   number: 10
   deleteAutomanagedNamespaces: false
-  
+
 tuningSets:
 - name: Uniformtinyqps
   qpsLoad:
@@ -226,8 +246,10 @@ steps:
       objectTemplatePath: "policy.yaml"
 ```
 
-
-Now, we need to specify deployment and propagation template. ClusterLoader2 by default adds parameter `Name` that you can use in your template. In our config, we also passed `Replicas` parameter. So our template for deployment and propagation policy will look like following:
+Now, we need to specify deployment and propagation template. ClusterLoader2 by default
+adds parameter `Name` that you can use in your template. In our config, we also passed
+`Replicas` parameter. So our template for deployment and propagation policy will look
+like following:
 
 ```yaml
 # deployment.yaml
@@ -281,11 +303,9 @@ spec:
       replicaSchedulingType: Divided
 ```
 
-
-
 ### Start Distributing
 
-To distributing resources,  run:
+To distributing resources, run:
 
 ```shell
 export KARMADA_APISERVERCONFIG=your_config
@@ -297,12 +317,16 @@ go run cmd/clusterloader.go --testconfig=config.yaml --provider=local --kubeconf
 The meaning of args above shows as following:
 
 - k8s-clients-number: the number of karmada apiserver client number.
-- skip-cluster-verification: whether to skip the cluster verification, which expects at least one schedulable node in the cluster.
-- enable-exec-service: whether to enable exec service that allows executing arbitrary commands from a pod running in the cluster.
+- skip-cluster-verification: whether to skip the cluster verification,
+  which expects at least one schedulable node in the cluster.
+- enable-exec-service: whether to enable exec service that allows executing
+  arbitrary commands from a pod running in the cluster.
 
-Since the resources of member cluster cannot be accessed in karmada control plane, we have to turn off enable-exec-service and cluster-verification.
+Since the resources of member cluster cannot be accessed in karmada control plane,
+we have to turn off enable-exec-service and cluster-verification.
 
-> Note: If the `deleteAutomanagedNamespaces` parameter in config file is set to true, when the whole distribution of resources is complete, the resources will be immediately deleted.
+> Note: If the `deleteAutomanagedNamespaces` parameter in config file is set to true,
+> when the whole distribution of resources is complete, the resources will be immediately deleted.
 
 ## Monitor Karmada control plane using Prometheus and Grafana
 
@@ -312,23 +336,21 @@ Since the resources of member cluster cannot be accessed in karmada control plan
 
 ### Create Grafana DashBoards to observe Karmada control plane metrics
 
-Here's an example to monitor the mutating api call latency for works and resourcebindings of the karmada apiserver through grafana. Monitor the metrics you want by modifying the Query statement.
+Here's an example to monitor the mutating api call latency for works and resourcebindings
+of the karmada apiserver through grafana. Monitor the metrics you want by modifying the Query statement.
 
 #### Create a dashboard
 
-> Follw the [Grafana support For Prometheus](https://prometheus.io/docs/visualization/grafana/)  document.
+> Follw the [Grafana support For Prometheus](https://prometheus.io/docs/visualization/grafana/) document.
 
 #### Modify Query Statement
 
 Enter the following Prometheus expression into the ` Query` field.
 
-````sql
+```sql
 histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH|GET|LIST", resource~="works|resourcebindings"}[5m])) by (resource, verb, le))
-````
+```
 
 The gragh will show as follow:
 
 ![grafana-dashboard](../resources/developers/grafana_metrics.png)
-
-
-


### PR DESCRIPTION
/kind documentation

This is a try to make the doc prettier. Performed two actions:

1. Run `npx prettier --w` to automatically remove blank lines, fix spaces, and fix code symbol like line 350
2. Tweak long lines to enable easily review changes that may occur later
