### PR TITLE
evolute PropagateDeps FeatureGate to Beta and enable it by default

### DIFF
--- a/docs/installation/install-binary.md
+++ b/docs/installation/install-binary.md
@@ -769,7 +769,7 @@ Documentation=https://github.com/karmada-io/karmada
 ExecStart=/usr/local/sbin/karmada-controller-manager \
   --bind-address 0.0.0.0 \
   --cluster-status-update-frequency 10s \
-  --feature-gates "Failover=false,PropagateDeps=false" \
+  --feature-gates "Failover=false" \
   --kubeconfig /etc/karmada/karmada.kubeconfig \
   --logtostderr=true \
   --metrics-bind-address ":10358" \
@@ -821,7 +821,7 @@ Documentation=https://github.com/karmada-io/karmada
 ExecStart=/usr/local/sbin/karmada-scheduler \
   --bind-address 0.0.0.0 \
   --enable-scheduler-estimator=true \
-  --feature-gates "Failover=false,PropagateDeps=false" \
+  --feature-gates "Failover=false" \
   --kubeconfig /etc/karmada/karmada.kubeconfig \
   --logtostderr=true \
   --scheduler-estimator-port 10352 \

--- a/docs/userguide/scheduling/cluster-resources.md
+++ b/docs/userguide/scheduling/cluster-resources.md
@@ -126,7 +126,7 @@ kubectl --kubeconfig ~/.kube/karmada.config --context karmada-host edit deploy/k
         - --bind-address=0.0.0.0
         - --cluster-status-update-frequency=10s
         - --secure-port=10357
-        - --feature-gates=PropagateDeps=true,Failover=true,GracefulEviction=true,CustomizedClusterResourceModeling=true
+        - --feature-gates=Failover=true,GracefulEviction=true,CustomizedClusterResourceModeling=true
         - --v=4
 
 ```

--- a/docs/userguide/scheduling/propagate-dependencies.md
+++ b/docs/userguide/scheduling/propagate-dependencies.md
@@ -13,6 +13,9 @@ We can install Karmada by referring to [quick-start](https://github.com/karmada-
 `hack/local-up-karmada.sh` script which is also used to run our E2E cases.
 
 ### Enable PropagateDeps feature
+
+`PropagateDeps` feature gate has evolved to the Beta sine Karmada v1.4 and is enabled by default. If you use the Karmada 1.3 or earlier, you need to enable this feature gate.
+
 ```bash
 kubectl edit deployment karmada-controller-manager -n karmada-system
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/install-binary.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/install-binary.md
@@ -774,7 +774,7 @@ Documentation=https://github.com/karmada-io/karmada
 ExecStart=/usr/local/sbin/karmada-controller-manager \
   --bind-address 0.0.0.0 \
   --cluster-status-update-frequency 10s \
-  --feature-gates "Failover=false,PropagateDeps=false" \
+  --feature-gates "Failover=false" \
   --kubeconfig /etc/karmada/karmada.kubeconfig \
   --logtostderr=true \
   --metrics-bind-address ":10358" \
@@ -826,7 +826,7 @@ Documentation=https://github.com/karmada-io/karmada
 ExecStart=/usr/local/sbin/karmada-scheduler \
   --bind-address 0.0.0.0 \
   --enable-scheduler-estimator=true \
-  --feature-gates "Failover=false,PropagateDeps=false" \
+  --feature-gates "Failover=false" \
   --kubeconfig /etc/karmada/karmada.kubeconfig \
   --logtostderr=true \
   --scheduler-estimator-port 10352 \

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/scheduling/cluster-resources.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/scheduling/cluster-resources.md
@@ -125,7 +125,7 @@ kubectl --kubeconfig ~/.kube/karmada.config --context karmada-host edit deploy/k
         - --bind-address=0.0.0.0
         - --cluster-status-update-frequency=10s
         - --secure-port=10357
-        - --feature-gates=PropagateDeps=true,Failover=true,GracefulEviction=true,CustomizedClusterResourceModeling=true
+        - --feature-gates=Failover=true,GracefulEviction=true,CustomizedClusterResourceModeling=true
         - --v=4
 
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/scheduling/propagate-dependencies.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/scheduling/propagate-dependencies.md
@@ -13,6 +13,9 @@ We can install Karmada by referring to [quick-start](https://github.com/karmada-
 `hack/local-up-karmada.sh` script which is also used to run our E2E cases.
 
 ### Enable PropagateDeps feature
+
+`PropagateDeps` feature gate has evolved to the Beta sine Karmada v1.4 and is enabled by default. If you use the Karmada 1.3 or earlier, you need to enable this feature gate.
+
 ```bash
 kubectl edit deployment karmada-controller-manager -n karmada-system
 ```


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

**What type of PR is this?**

/kind documentation
/kind failing-test

**What this PR does / why we need it**:

The PropagateDeps feautre hes been stably supported n multiple versions (since version v1.1). It is planned to enable the PropagateDeps FeatureGate by default and evolute it to beta.

Change association: https://github.com/karmada-io/karmada/pull/2875

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

```
karmada-controller-manager: evolute PropagateDeps FeatureGate to Beta  and enable it by default
```
