### PR TITLE
Update default resource interpreter documents for PodDisruptionBudget

### DIFF
--- a/docs/userguide/globalview/customizing-resource-interpreter.md
+++ b/docs/userguide/globalview/customizing-resource-interpreter.md
@@ -83,6 +83,7 @@ Supported resources:
 - Pod(v1)
 - PersistentVolume(V1)
 - PersistentVolumeClaim(v1)
+- PodDisruptionBudget(policy/v1)
 
 ### InterpretStatus
 
@@ -93,6 +94,7 @@ Supported resources:
 - Job(batch/v1)
 - DaemonSet(apps/v1)
 - StatefulSet(apps/v1)
+- PodDisruptionBudget(policy/v1)
 
 ### InterpretDependency
 
@@ -114,6 +116,7 @@ Supported resources:
 - Service(v1)
 - Ingress(networking.k8s.io/v1)
 - PersistentVolumeClaim(v1)
+- PodDisruptionBudget(policy/v1)
 
 ## Customized Interpreter
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/globalview/customizing-resource-interpreter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/globalview/customizing-resource-interpreter.md
@@ -83,6 +83,7 @@ Supported resources:
 - Pod(v1)
 - PersistentVolume(V1)
 - PersistentVolumeClaim(v1)
+- PodDisruptionBudget(policy/v1)
 
 ### InterpretStatus
 
@@ -93,6 +94,7 @@ Supported resources:
 - Job(batch/v1)
 - DaemonSet(apps/v1)
 - StatefulSet(apps/v1)
+- PodDisruptionBudget(policy/v1)
 
 ### InterpretDependency
 
@@ -114,6 +116,7 @@ Supported resources:
 - Service(v1)
 - Ingress(networking.k8s.io/v1)
 - PersistentVolumeClaim(v1)
+- PodDisruptionBudget(policy/v1)
 
 ## Customized Interpreter
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
Update documents as per https://github.com/karmada-io/karmada/pull/2997 which introduced a default interpreter(`AggregateStatus`) for `PodDisruptionBudget(policy/v1)`.

**Which issue(s) this PR fixes**:
Fixes #287 

**Special notes for your reviewer**:


