### PR TITLE
fix cluster number , match the describe infos.

### DIFF
--- a/docs/userguide/failover/failover-analysis.md
+++ b/docs/userguide/failover/failover-analysis.md
@@ -131,7 +131,7 @@ spec:
 ```
 </details>
 
-Suppose there are 5 member clusters, and the initial scheduling result is in member1 and member2. When member2 fails, it triggers rescheduling.
+Suppose there are 4 member clusters, and the initial scheduling result is in member1 and member2. When member2 fails, it triggers rescheduling.
 
 It should be noted that rescheduling will not delete the application on the ready cluster member1. In the remaining 3 clusters, only member3 and member5 match the `clusterAffinity` policy.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/failover/failover-analysis.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/failover/failover-analysis.md
@@ -126,7 +126,7 @@ spec:
 ```
 </details>
 
-假设有5个成员集群，初始调度结果在member1和member2集群中。当member2集群发生故障，将触发调度器重调度。
+假设有4个成员集群，初始调度结果在member1和member2集群中。当member2集群发生故障，将触发调度器重调度。
 
 需要注意的是，重调度不会删除原本状态为Ready的集群member1上的工作负载。在其余3个集群中，只有member3和member5匹配`clusterAffinity`策略。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3/userguide/failover/failover.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3/userguide/failover/failover.md
@@ -221,7 +221,7 @@ spec:
 ```
 </details>
 
-Suppose there are 5 member clusters, and the initial scheduling result is in member1 and member2. When member2 fails, it triggers rescheduling.
+Suppose there are 4 member clusters, and the initial scheduling result is in member1 and member2. When member2 fails, it triggers rescheduling.
 
 It should be noted that rescheduling will not delete the application on the ready cluster member1. In the remaining 3 clusters, only member3 and member5 match the `clusterAffinity` policy.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/userguide/failover/failover-analysis.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/userguide/failover/failover-analysis.md
@@ -126,7 +126,7 @@ spec:
 ```
 </details>
 
-假设有5个成员集群，初始调度结果在member1和member2集群中。当member2集群发生故障，将触发调度器重调度。
+假设有4个成员集群，初始调度结果在member1和member2集群中。当member2集群发生故障，将触发调度器重调度。
 
 需要注意的是，重调度不会删除原本状态为Ready的集群member1上的工作负载。在其余3个集群中，只有member3和member5匹配`clusterAffinity`策略。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/userguide/failover/failover-analysis.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/userguide/failover/failover-analysis.md
@@ -126,7 +126,7 @@ spec:
 ```
 </details>
 
-假设有5个成员集群，初始调度结果在member1和member2集群中。当member2集群发生故障，将触发调度器重调度。
+假设有4个成员集群，初始调度结果在member1和member2集群中。当member2集群发生故障，将触发调度器重调度。
 
 需要注意的是，重调度不会删除原本状态为Ready的集群member1上的工作负载。在其余3个集群中，只有member3和member5匹配`clusterAffinity`策略。
 

--- a/versioned_docs/version-v1.3/userguide/failover/failover.md
+++ b/versioned_docs/version-v1.3/userguide/failover/failover.md
@@ -221,7 +221,7 @@ spec:
 ```
 </details>
 
-Suppose there are 5 member clusters, and the initial scheduling result is in member1 and member2. When member2 fails, it triggers rescheduling.
+Suppose there are 4 member clusters, and the initial scheduling result is in member1 and member2. When member2 fails, it triggers rescheduling.
 
 It should be noted that rescheduling will not delete the application on the ready cluster member1. In the remaining 3 clusters, only member3 and member5 match the `clusterAffinity` policy.
 

--- a/versioned_docs/version-v1.4/userguide/failover/failover-analysis.md
+++ b/versioned_docs/version-v1.4/userguide/failover/failover-analysis.md
@@ -130,7 +130,7 @@ spec:
 ```
 </details>
 
-Suppose there are 5 member clusters, and the initial scheduling result is in member1 and member2. When member2 fails, it triggers rescheduling.
+Suppose there are 4 member clusters, and the initial scheduling result is in member1 and member2. When member2 fails, it triggers rescheduling.
 
 It should be noted that rescheduling will not delete the application on the ready cluster member1. In the remaining 3 clusters, only member3 and member5 match the `clusterAffinity` policy.
 

--- a/versioned_docs/version-v1.5/userguide/failover/failover-analysis.md
+++ b/versioned_docs/version-v1.5/userguide/failover/failover-analysis.md
@@ -130,7 +130,7 @@ spec:
 ```
 </details>
 
-Suppose there are 5 member clusters, and the initial scheduling result is in member1 and member2. When member2 fails, it triggers rescheduling.
+Suppose there are 4 member clusters, and the initial scheduling result is in member1 and member2. When member2 fails, it triggers rescheduling.
 
 It should be noted that rescheduling will not delete the application on the ready cluster member1. In the remaining 3 clusters, only member3 and member5 match the `clusterAffinity` policy.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The demo yaml 's clusters is 

```
placement:
    clusterAffinity:
      clusterNames:
        - member1
        - member2
        - member3
        - member5
```
.
        
But the describe is a little confused.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


