### PR TITLE
add windsonsea to doc-reviewers

### DIFF
--- a/i18n/OWNERS
+++ b/i18n/OWNERS
@@ -1,6 +1,7 @@
 reviewers:
 - Poor12
 - SAMZONG
+- windsonsea
 approvers:
 - Poor12
 - SAMZONG


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

for karmada-io/community#39

**What this PR does / why we need it**:

I joined Karmada one year ago and have actively contributed to the project. By this time, I have [authored 24 PRs](https://github.com/karmada-io/website/pulls/windsonsea), and I have also [reviewed 17 PRs](https://github.com/karmada-io/website/pulls?q=is%3Apr+is%3Aopen+reviewed-by%3A%40me).

Recently, with the increase in en-zh PRs, I have noticed that the review process is not always timely. To address this, I would like to take on the responsibility of improving the documentation, particularly for Chinese content, in order to provide convenience for native Chinese developers.
