### PR TITLE
Add kubeconfig in  unified auth

### DIFF
--- a/docs/userguide/bestpractices/unified-auth.md
+++ b/docs/userguide/bestpractices/unified-auth.md
@@ -75,7 +75,7 @@ kubectl --kubeconfig $HOME/.kube/karmada.config --context karmada-apiserver appl
 Manually create a long-lived api token for the serviceaccount `tom`:
 
 ```shell
-kubectl apply -f - <<EOF
+kubectl apply --kubeconfig ~/.kube/karmada.config -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/bestpractices/unified-auth.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/bestpractices/unified-auth.md
@@ -75,7 +75,7 @@ kubectl --kubeconfig $HOME/.kube/karmada.config --context karmada-apiserver appl
 Manually create a long-lived api token for the serviceaccount `tom`:
 
 ```shell
-kubectl apply -f - <<EOF
+kubectl apply --kubeconfig ~/.kube/karmada.config -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR specifies which `kubeconfig`  file to use in the step3 of the unified authentication to avoid any user confusion.

**Which issue(s) this PR fixes**:
Fixes #437


