### PR TITLE
Fix dependencies lua script bug

### DIFF
--- a/docs/userguide/globalview/customizing-resource-interpreter.md
+++ b/docs/userguide/globalview/customizing-resource-interpreter.md
@@ -310,7 +310,7 @@ spec:
         function GetDependencies(desiredObj)
           dependentSas = {}
           refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
             dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
           end
           local idx = 1

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/globalview/customizing-resource-interpreter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/globalview/customizing-resource-interpreter.md
@@ -294,7 +294,7 @@ spec:
         function GetDependencies(desiredObj)
           dependentSas = {}
           refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
             dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
           end
           local idx = 1

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/karmadactl/karmadactl-usage-conventions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/karmadactl/karmadactl-usage-conventions.md
@@ -134,7 +134,7 @@ spec:
         function GetDependencies(desiredObj)
           dependentSas = {}
           refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
             dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
           end
           local idx = 1

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/reference/karmadactl/karmadactl-usage-conventions.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/reference/karmadactl/karmadactl-usage-conventions.md
@@ -140,7 +140,7 @@ spec:
         function GetDependencies(desiredObj)
           dependentSas = {}
           refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
             dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
           end
           local idx = 1

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/userguide/globalview/customizing-resource-interpreter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/userguide/globalview/customizing-resource-interpreter.md
@@ -187,7 +187,7 @@ spec:
         function GetDependencies(desiredObj)
           dependentSas = {}
           refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
             dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
           end
           local idx = 1

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/userguide/globalview/customizing-resource-interpreter.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/userguide/globalview/customizing-resource-interpreter.md
@@ -292,7 +292,7 @@ spec:
         function GetDependencies(desiredObj)
           dependentSas = {}
           refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
             dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
           end
           local idx = 1

--- a/versioned_docs/version-v1.4/reference/karmadactl/karmadactl-usage-conventions.md
+++ b/versioned_docs/version-v1.4/reference/karmadactl/karmadactl-usage-conventions.md
@@ -134,7 +134,7 @@ spec:
         function GetDependencies(desiredObj)
           dependentSas = {}
           refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
             dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
           end
           local idx = 1

--- a/versioned_docs/version-v1.5/reference/karmadactl/karmadactl-usage-conventions.md
+++ b/versioned_docs/version-v1.5/reference/karmadactl/karmadactl-usage-conventions.md
@@ -140,7 +140,7 @@ spec:
         function GetDependencies(desiredObj)
           dependentSas = {}
           refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
             dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
           end
           local idx = 1

--- a/versioned_docs/version-v1.5/userguide/globalview/customizing-resource-interpreter.md
+++ b/versioned_docs/version-v1.5/userguide/globalview/customizing-resource-interpreter.md
@@ -203,7 +203,7 @@ spec:
         function GetDependencies(desiredObj)
           dependentSas = {}
           refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
             dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
           end
           local idx = 1

--- a/versioned_docs/version-v1.6/userguide/globalview/customizing-resource-interpreter.md
+++ b/versioned_docs/version-v1.6/userguide/globalview/customizing-resource-interpreter.md
@@ -308,7 +308,7 @@ spec:
         function GetDependencies(desiredObj)
           dependentSas = {}
           refs = {}
-          if desiredObj.spec.template.spec.serviceAccountName ~= '' and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
+          if desiredObj.spec.template.spec.serviceAccountName ~= nil and desiredObj.spec.template.spec.serviceAccountName ~= 'default' then
             dependentSas[desiredObj.spec.template.spec.serviceAccountName] = true
           end
           local idx = 1


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind bug

**What this PR does / why we need it**:

When a field of an object is empty, retrieving its value will yield nil:

![image](https://github.com/karmada-io/karmada/assets/78244870/df6fe0fb-dd7f-4434-b9b0-d362e5f9c5b2)

An error will occur when using this nil value to index a table.

![image](https://github.com/karmada-io/karmada/assets/78244870/09788f50-77c4-467a-a7e4-b832d3ed4ae9)

Therefore, we need to correct these mistakes in writing

we can test with the command
```shell
karmadactl interpret -f resource-interpreter-customization.yaml --operation interpretDependency --observed-file observed-deploy-nginx.yaml
```

<details>
<summary>observed-deploy-nginx.yam</summary>

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  paused: true
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx
        name: nginx
status:
  availableReplicas: 2
  observedGeneration: 1
  readyReplicas: 2
  replicas: 2
  updatedReplicas: 2
```

</details>

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


