### PR TITLE
doc: fix typo error in --karmada-data params

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/installation.md
@@ -29,7 +29,7 @@ title: 安装概述
 假设你已将集群的 `kubeconfig` 文件放到了 `$HOME/.kube/config` 或用 `KUBECONFIG` 环境变量指定了该路径。
 否则，你应将 `--kubeconfig` 标志设置为以下命令来指定该配置文件。
 
-> 注：从 v1.0 开始可以使用 `init` 命令。运行 `init` 命令需要升级的权限才能将多个用户的公共配置（证书、crd）存储在默认位置 `/etc/karmada` 下，您可以通过标志 `--karmada data` 和 `--karmada-pki` 覆盖此位置。有关更多详细信息或用法信息，请参阅CLI。
+> 注：从 v1.0 开始可以使用 `init` 命令。运行 `init` 命令需要升级的权限才能将多个用户的公共配置（证书、crd）存储在默认位置 `/etc/karmada` 下，您可以通过标志 `--karmada-data` 和 `--karmada-pki` 覆盖此位置。有关更多详细信息或用法信息，请参阅CLI。
 
 运行以下命令进行安装：
 ```bash

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/installation/installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/installation/installation.md
@@ -29,7 +29,7 @@ title: 安装概述
 假设你已将集群的 `kubeconfig` 文件放到了 `$HOME/.kube/config` 或用 `KUBECONFIG` 环境变量指定了该路径。
 否则，你应将 `--kubeconfig` 标志设置为以下命令来指定该配置文件。
 
-> 注：从 v1.0 开始可以使用 `init` 命令。运行 `init` 命令需要升级的权限才能将多个用户的公共配置（证书、crd）存储在默认位置 `/etc/karmada` 下，您可以通过标志 `--karmada data` 和 `--karmada-pki` 覆盖此位置。有关更多详细信息或用法信息，请参阅CLI。
+> 注：从 v1.0 开始可以使用 `init` 命令。运行 `init` 命令需要升级的权限才能将多个用户的公共配置（证书、crd）存储在默认位置 `/etc/karmada` 下，您可以通过标志 `--karmada-data` 和 `--karmada-pki` 覆盖此位置。有关更多详细信息或用法信息，请参阅CLI。
 
 运行以下命令进行安装：
 ```bash


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
There is a typo error in installation doc (Chinese version), spell `--karmada-data` to `--karmada data`, this commit fixed this mistake

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
No

