### PR TITLE
Update `istio x create-remote-secret` examples to `istio create-remote-secret`

### DIFF
--- a/docs/userguide/service/working-with-istio-on-flat-network.md
+++ b/docs/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/docs/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/docs/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/service/working-with-istio-on-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3/userguide/service/working-with-istio-on-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/userguide/service/working-with-istio-on-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/userguide/service/working-with-istio-on-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.5/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/userguide/service/working-with-istio-on-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/userguide/service/working-with-istio-on-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/userguide/service/working-with-istio-on-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/userguide/service/working-with-istio-on-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.9/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/versioned_docs/version-v1.3/userguide/service/working-with-istio-on-flat-network.md
+++ b/versioned_docs/version-v1.3/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/versioned_docs/version-v1.3/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/versioned_docs/version-v1.3/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/versioned_docs/version-v1.4/userguide/service/working-with-istio-on-flat-network.md
+++ b/versioned_docs/version-v1.4/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/versioned_docs/version-v1.4/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/versioned_docs/version-v1.4/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/versioned_docs/version-v1.5/userguide/service/working-with-istio-on-flat-network.md
+++ b/versioned_docs/version-v1.5/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/versioned_docs/version-v1.5/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/versioned_docs/version-v1.5/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/versioned_docs/version-v1.6/userguide/service/working-with-istio-on-flat-network.md
+++ b/versioned_docs/version-v1.6/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/versioned_docs/version-v1.6/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/versioned_docs/version-v1.6/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/versioned_docs/version-v1.7/userguide/service/working-with-istio-on-flat-network.md
+++ b/versioned_docs/version-v1.7/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/versioned_docs/version-v1.7/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/versioned_docs/version-v1.7/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/versioned_docs/version-v1.8/userguide/service/working-with-istio-on-flat-network.md
+++ b/versioned_docs/version-v1.8/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/versioned_docs/version-v1.8/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/versioned_docs/version-v1.8/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:

--- a/versioned_docs/version-v1.9/userguide/service/working-with-istio-on-flat-network.md
+++ b/versioned_docs/version-v1.9/userguide/service/working-with-istio-on-flat-network.md
@@ -199,7 +199,7 @@ kubectl config use-context member1
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
+istioctl create-remote-secret --name=member1 > istio-remote-secret-member1.yaml
 ```
 
 ### Prepare member2 cluster secret
@@ -212,7 +212,7 @@ kubectl config use-context member2
 
 2. Create istio remote secret for member1:
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 ### Apply istio remote secret

--- a/versioned_docs/version-v1.9/userguide/service/working-with-istio-on-non-flat-network.md
+++ b/versioned_docs/version-v1.9/userguide/service/working-with-istio-on-non-flat-network.md
@@ -215,7 +215,7 @@ kubectl config use-context member2
 Prepare member2 cluster secret
 
 ```bash
-istioctl x create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
+istioctl create-remote-secret --name=member2 > istio-remote-secret-member2.yaml
 ```
 
 Switch to `member1`:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

The `create-remote-secret` command in Istio is no longer experimental, therefore, all examples using `istio x create-remote-secret` have been updated to `istio create-remote-secret`. This update ensures consistency and reflects the current status of the command.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

It was observed that using `istio x create-remote-secret` may result in errors due to missing arguments, such as `--name`. By transitioning all examples to `istio create-remote-secret`, these potential errors are avoided, and users can seamlessly utilize the command without issues.

For more detailed information, please refer to the Istio documentation [here](https://istio.io/latest/docs/reference/commands/istioctl/#istioctl-create-remote-secret).


