### PR TITLE
Fix typos on docs

### DIFF
--- a/docs/core-concepts/concepts.md
+++ b/docs/core-concepts/concepts.md
@@ -10,9 +10,9 @@ Karmada uses the Kubernetes Native API definition for the federated resource tem
 
 ## Propagation Policy
 
-Karmada offers a standalone Propagation(placement) Policy API to define multi-cluster scheduling and spreading requirements.
+Karmada offers a standalone Propagation (placement) Policy API to define multi-cluster scheduling and spreading requirements.
 
-- Support 1:n mapping of policy: workload. Users don't need to indicate scheduling constraints every time creating federated applications.
+- Support 1:n mapping of policy:workloads. Users don't need to indicate scheduling constraints every time creating federated applications.
 
 - With default policies, users can directly interact with the Kubernetes API.
 

--- a/docs/key-features/features.md
+++ b/docs/key-features/features.md
@@ -42,7 +42,7 @@ Much like k8s scheduling, Karmada support different scheduling policy. The overa
 
 ![overall-relationship.png](../resources/key-features/overall-scheduling.png)
 
-If one cluster does not have enough resource to accommodate their pods, Karamda will reschedule the pods. The overall rescheduling process is shown in the following figure:  
+If one cluster does not have enough resource to accommodate their pods, Karmada will reschedule the pods. The overall rescheduling process is shown in the following figure:  
 
 ![overall-relationship.png](../resources/key-features/overall-rescheduling.png)
 

--- a/versioned_docs/version-v1.3/faq/faq.md
+++ b/versioned_docs/version-v1.3/faq/faq.md
@@ -1,5 +1,5 @@
 ---
-title: FAQ(Frequently Asked Questions)
+title: FAQ (Frequently Asked Questions)
 ---
 
 ## What is the difference between PropagationPolicy and ClusterPropagationPolicy?


### PR DESCRIPTION
DCO keeps failing despite the sign-off being included in the commit message.

Fix: after removing privacy option from github email, git cache had to be updated to reflect the changes.