### PR TITLE
add mutate configuration description for upgrading v1.9-v1.10

### DIFF
--- a/docs/administrator/upgrading/v1.9-v1.10.md
+++ b/docs/administrator/upgrading/v1.9-v1.10.md
@@ -15,17 +15,66 @@ Follow the [Regular Upgrading Process](./README.md).
 ### Deprecation
 
 * The following labels have been deprecated from release `v1.8.0` and now have been removed:
-    * `resourcebinding.karmada.io/uid`
-    * `clusterresourcebinding.karmada.io/uid`
-    * `work.karmada.io/uid`
-    * `propagationpolicy.karmada.io/uid`
-    * `clusterpropagationpolicy.karmada.io/uid`
+  * `resourcebinding.karmada.io/uid`
+  * `clusterresourcebinding.karmada.io/uid`
+  * `work.karmada.io/uid`
+  * `propagationpolicy.karmada.io/uid`
+  * `clusterpropagationpolicy.karmada.io/uid`
 * The following labels now have been deprecated and removed:
-    * `resourcebinding.karmada.io/key` replaced by `resourcebinding.karmada.io/permanent-id`
-    * `clusterresourcebinding.karmada.io/key` replaced by `clusterresourcebinding.karmada.io/permanent-id`
-    * `work.karmada.io/namespace` replaced by `work.karmada.io/permanent-id`
-    * `work.karmada.io/name` replaced by `work.karmada.io/permanent-id`
+  * `resourcebinding.karmada.io/key` replaced by `resourcebinding.karmada.io/permanent-id`
+  * `clusterresourcebinding.karmada.io/key` replaced by `clusterresourcebinding.karmada.io/permanent-id`
+  * `work.karmada.io/namespace` replaced by `work.karmada.io/permanent-id`
+  * `work.karmada.io/name` replaced by `work.karmada.io/permanent-id`
 * `karmadactl`: The flag `--cluster-zone`, which was deprecated in release 1.7 and replaced by `--cluster-zones`, now has been removed.
+
+### Webhook Configuration
+
+In v1.10, we move the logic of generating Permanent ID from the karmada-controller-manager component to the Karmada-webhook component, so you need to add mutate configuration for ResourceBinding/ClusterResourceBinding/MultiClusterService type resources in the `mutating-config` MutatingWebhookConfiguration resource object. The specific configuration is as follows:
+
+```yaml
+  - name: resourcebinding.karmada.io
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [ "work.karmada.io" ]
+        apiVersions: [ "*" ]
+        resources: [ "resourcebindings" ]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/mutate-resourcebinding
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3
+  - name: clusterresourcebinding.karmada.io
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [ "work.karmada.io" ]
+        apiVersions: [ "*" ]
+        resources: [ "clusterresourcebindings" ]
+        scope: "Cluster"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/mutate-clusterresourcebinding
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3
+  - name: multiclusterservice.karmada.io
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: [ "networking.karmada.io" ]
+        apiVersions: [ "*" ]
+        resources: [ "multiclusterservices" ]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/mutate-multiclusterservice
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3
+```
 
 ### karmada-search
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/administrator/upgrading/v1.9-v1.10.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/administrator/upgrading/v1.9-v1.10.md
@@ -15,17 +15,66 @@ title: v1.9 升级到 v1.10
 ### 弃用
 
 * 以下 Labels 已从版本 `v1.8.0` 中弃用，现在已被移除：
-    * `resourcebinding.karmada.io/uid`
-    * `clusterresourcebinding.karmada.io/uid`
-    * `work.karmada.io/uid`
-    * `propagationpolicy.karmada.io/uid`
-    * `clusterpropagationpolicy.karmada.io/uid`
+  * `resourcebinding.karmada.io/uid`
+  * `clusterresourcebinding.karmada.io/uid`
+  * `work.karmada.io/uid`
+  * `propagationpolicy.karmada.io/uid`
+  * `clusterpropagationpolicy.karmada.io/uid`
 * 以下 Labels 现已弃用并删除：
-    * `resourcebinding.karmada.io/key` 被替换为 `resourcebinding.karmada.io/permanent-id`
-    * `clusterresourcebinding.karmada.io/key` 被替换为 `clusterresourcebinding.karmada.io/permanent-id`
-    * `work.karmada.io/namespace` 被替换为`work.karmada.io/permanent-id`
-    * `work.karmada.io/name` 被替换为 `work.karmada.io/permanent-id`
+  * `resourcebinding.karmada.io/key` 被替换为 `resourcebinding.karmada.io/permanent-id`
+  * `clusterresourcebinding.karmada.io/key` 被替换为 `clusterresourcebinding.karmada.io/permanent-id`
+  * `work.karmada.io/namespace` 被替换为`work.karmada.io/permanent-id`
+  * `work.karmada.io/name` 被替换为 `work.karmada.io/permanent-id`
 * `karmadactl`: 参数“--cluster-zone”在版本 1.7 中已弃用并被“--cluster-zones”取代，现已被删除。
+
+### Webhook 配置
+
+v1.10 版本将生成 Permanent ID 的工作从 karmada-controller-manager 组件中移至了 Karmada-webhook组件，因此您需要在 `mutating-config` MutatingWebhookConfiguration 资源对象中增加对 ResourceBinding/ClusterResourceBinding/MultiClusterService 类型资源的 mutate 操作，具体配置如下：
+
+```yaml
+  - name: resourcebinding.karmada.io
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [ "work.karmada.io" ]
+        apiVersions: [ "*" ]
+        resources: [ "resourcebindings" ]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/mutate-resourcebinding
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3
+  - name: clusterresourcebinding.karmada.io
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [ "work.karmada.io" ]
+        apiVersions: [ "*" ]
+        resources: [ "clusterresourcebindings" ]
+        scope: "Cluster"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/mutate-clusterresourcebinding
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3
+  - name: multiclusterservice.karmada.io
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: [ "networking.karmada.io" ]
+        apiVersions: [ "*" ]
+        resources: [ "multiclusterservices" ]
+        scope: "Namespaced"
+    clientConfig:
+      url: https://karmada-webhook.karmada-system.svc:443/mutate-multiclusterservice
+      caBundle: {{caBundle}}
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 3
+```
 
 ### karmada-search
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

In order to prevent users from forgetting to update the MutatingWebhookConfiguration resource during the upgrade process, relevant instructions are added.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


