### PR TITLE
add deprecated label for upgrading v1.9-v1.10

### DIFF
--- a/docs/administrator/upgrading/v1.9-v1.10.md
+++ b/docs/administrator/upgrading/v1.9-v1.10.md
@@ -25,6 +25,7 @@ Follow the [Regular Upgrading Process](./README.md).
   * `clusterresourcebinding.karmada.io/key` replaced by `clusterresourcebinding.karmada.io/permanent-id`
   * `work.karmada.io/namespace` replaced by `work.karmada.io/permanent-id`
   * `work.karmada.io/name` replaced by `work.karmada.io/permanent-id`
+  * `resourcebinding.karmada.io/depended-id`
 * `karmadactl`: The flag `--cluster-zone`, which was deprecated in release 1.7 and replaced by `--cluster-zones`, now has been removed.
 
 ### Webhook Configuration

--- a/i18n/zh/docusaurus-plugin-content-docs/current/administrator/upgrading/v1.9-v1.10.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/administrator/upgrading/v1.9-v1.10.md
@@ -25,6 +25,7 @@ title: v1.9 升级到 v1.10
   * `clusterresourcebinding.karmada.io/key` 被替换为 `clusterresourcebinding.karmada.io/permanent-id`
   * `work.karmada.io/namespace` 被替换为`work.karmada.io/permanent-id`
   * `work.karmada.io/name` 被替换为 `work.karmada.io/permanent-id`
+  * `resourcebinding.karmada.io/depended-id`
 * `karmadactl`: 参数“--cluster-zone”在版本 1.7 中已弃用并被“--cluster-zones”取代，现已被删除。
 
 ### Webhook 配置


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In order to prevent users from continuing to use deprecated labels after upgrading, we have added instructions.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


