### PR TITLE
clean up namespace management and add manual option

### DIFF
--- a/docs/userguide/bestpractices/namespace-management.md
+++ b/docs/userguide/bestpractices/namespace-management.md
@@ -2,16 +2,24 @@
 title: Namespace Management
 ---
 
-In a Kubernetes cluster, workloads are deployed in a certain namespace. Multi-cluster deployments mean multiple namespaces. If you want to manage them in a unified manner, `karmada-controller-manager` will be the solution for you, which propagates the namespace you created in Karmada to member clusters.
+In a Kubernetes cluster, workloads are deployed into a namespace.
+Multi-cluster deployments mean each namespace must exists in multiple clusters.
+If you want to manage these namespaces in a unified manner, `karmada-controller-manager` [namespace sync controller](https://github.com/karmada-io/karmada/blob/master/pkg/controllers/namespace/namespace_sync_controller.go) is a solution,
+which propagates namespaces from Karmada to member clusters.
 
 ## Default namespace propagation
-All namespaces, except those reserved, will be automatically propagated to all member clusters. Reserved namespaces are `karmada-system`,`karmada-cluster`, `karmada-es-*`, `kube-*`, and `default`.
+All namespaces, except those reserved, will be propagated to all member clusters.
+Reserved namespaces are `karmada-system`,`karmada-cluster`, `karmada-es-*`, `kube-*` (configured via cli option, see below), and `default`.
 
 ## Skip namespace auto propagation
-If you don't want to propagate a namespace automatically, configure `karmada-controller-manager` or label the namespace.
 
-### Configuring `karmada-controller-manager`
-Flag `skipped-propagating-namespaces` could be configured to skip namespace auto propagation in `karmada-controller-manager`. Here is an example:
+If you don't want to propagate a namespace automatically:
+- Option A: Configure `karmada-controller-manager`
+- Option B: Label the namespace
+- Option C: use custom namespace propagation
+
+### Option A: Configure `karmada-controller-manager`
+The flag `--skipped-propagating-namespaces` can skip namespace auto propagation in `karmada-controller-manager` which defaults to the regex "kube-.*". Here is an example:
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -34,10 +42,12 @@ spec:
             - /bin/karmada-controller-manager
             - --skipped-propagating-namespaces=ns1,ns2
 ```
-`ns1` and `ns2` will not be propagated to all the member clusters.
+With this change:
+- `ns1` and `ns2` will not be propagated to all the member clusters.
+- the previously ignored "kube-.*" namespaces will be propagated to all the member clusters.
 
-### Labeling the namespace
-Label `namespace.karmada.io/skip-auto-propagation: "true"` could be configured to skip namespace auto propagation. Here is an example:
+### Option B: Label the namespace
+Configure label `namespace.karmada.io/skip-auto-propagation: "true"` to skip namespace auto propagation. Here is an example:
 ```yaml
 apiVersion: v1
 kind: Namespace
@@ -47,3 +57,55 @@ metadata:
     namespace.karmada.io/skip-auto-propagation: "true"
 ```
 > Note: If the namespace has been propagated to member clusters, labeling the namespace with `namespace.karmada.io/skip-auto-propagation: "true"` will not trigger member clusters to delete the namespace, but the namespace will not be propagated to newly joined member clusters.
+
+### Option C: use custom namespace propagation.
+
+If you want to take full control of which namespaces get propagated this option offers the most flexibility,
+but also means you have to add new clusters to the propagation policy yourself.
+
+#### Step 1: Disable the namespace-sync-controller (which is called "namespace" internally)
+
+Change the `karmada-controller-manager` command to not run the "namespace" controller:
+```yaml
+command:
+- /bin/karmada-controller-manager
+- --controllers=*,-namespace
+```
+
+#### Step 2: Create a clusterpropagationpolicy to propagate namespaces
+
+Example:
+
+```yaml
+apiVersion: policy.karmada.io/v1alpha1
+kind: ClusterPropagationPolicy
+metadata:
+  labels:
+    role: namespace
+  name: namespace
+spec:
+  conflictResolution: Overwrite
+  placement:
+    clusterAffinity:
+      clusterNames:
+      - cluster-a
+      - cluster-b
+  resourceSelectors:
+  - apiVersion: v1
+    kind: Namespace
+    labelSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-public
+        - kube-node-lease
+        - default
+        - karmada-system
+        - karmada-cluster
+      - key: karmada.io/managed
+        operator: NotIn
+        values:
+        - "true"
+```


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
- there was no option documented about how to manually take control of namespace propagation
- the skip option did not call out that kube-.* is the default and would be replaced

**Which issue(s) this PR fixes**:
fixes https://github.com/karmada-io/karmada/issues/5098

**Special notes for your reviewer**:


