### PR TITLE
docs: add a hint in the resource-propagation

### DIFF
--- a/docs/userguide/scheduling/resource-propagating.md
+++ b/docs/userguide/scheduling/resource-propagating.md
@@ -10,6 +10,8 @@ Here, we use PropagationPolicy as an example to describe how to propagate resour
 
 [Install Karmada](../../installation/installation.md) and prepare the [karmadactl command-line](../../installation/install-cli-tools.md) tool.
 
+> Note: We need to point kubectl to `<karmada-apiserver.config>` instead of the member cluster in advance. 
+
 ## Deploy a simplest multi-cluster Deployment
 
 ### Create a PropagationPolicy object


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
I am a user who is learning karmada for the first time.  When I was studying the `/docs/userguide/scheduling/resource-propagating` document, I repeatedly misunderstood the `api-server` pointed to by the resource used by kubectl.  I believe many people will have this question.

So I changed it a little bit here and added a Note.


**Special notes for your reviewer**:


