### PR TITLE
fix nits in application failover doc

### DIFF
--- a/docs/userguide/failover/application-failover.md
+++ b/docs/userguide/failover/application-failover.md
@@ -112,6 +112,7 @@ spec:
       decisionConditions:
         tolerationSeconds: 120
       purgeMode: Never
+  propagateDeps: true      # application failover is set, propagateDeps must be true
   resourceSelectors:
     - apiVersion: apps/v1
       kind: Deployment
@@ -195,4 +196,3 @@ You can edit `suppressDeletion` to false in `gracefulEvictionTasks` to evict the
 Application failover is still a work in progress. We are in the progress of gathering use cases. If you are interested in this feature, please feel free to start an enhancement issue to let us know.
 
 :::
-

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.10/userguide/failover/application-failover.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.10/userguide/failover/application-failover.md
@@ -114,6 +114,7 @@ spec:
       decisionConditions:
         tolerationSeconds: 120
       purgeMode: Never
+  propagateDeps: true      # application failover is set, propagateDeps must be true
   resourceSelectors:
     - apiVersion: apps/v1
       kind: Deployment


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

fix nits in application failover doc

run demo failed: `Error from server (Forbidden): error when creating "appfailover-pp.yaml": admission webhook "propagationpolicy.karmada.io" denied the request: spec.propagateDeps: Invalid value: false: application failover is set, propagateDeps must be true`, so do a simple fix.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:


