### PR TITLE
fix: typo in promote-legacy-workload.md

### DIFF
--- a/docs/administrator/migration/promote-legacy-workload.md
+++ b/docs/administrator/migration/promote-legacy-workload.md
@@ -28,7 +28,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          2m12s
 We can promote it to Karmada by executing the command below on the Karmada control plane.
 
 ```
-[root@master1]# karmadactl promote deployment nginx -n default -c member1
+[root@master1]# karmadactl promote deployment nginx -n default -C member1
 Resource "apps/v1, Resource=deployments"(default/nginx) is promoted successfully
 ```
 
@@ -52,7 +52,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          15m
 Most steps are same as those for clusters in `Push` mode. Only the flags of the `karmadactl promote` command are different.
 
 ```
-karmadactl promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
+karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
 ```
 
 For more flags and example about the command, you can use `karmadactl promote --help`.

--- a/versioned_docs/version-v1.10/administrator/migration/promote-legacy-workload.md
+++ b/versioned_docs/version-v1.10/administrator/migration/promote-legacy-workload.md
@@ -28,7 +28,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          2m12s
 We can promote it to Karmada by executing the command below on the Karmada control plane.
 
 ```
-[root@master1]# karmadactl promote deployment nginx -n default -c member1
+[root@master1]# karmadactl promote deployment nginx -n default -C member1
 Resource "apps/v1, Resource=deployments"(default/nginx) is promoted successfully
 ```
 
@@ -52,7 +52,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          15m
 Most steps are same as those for clusters in `Push` mode. Only the flags of the `karmadactl promote` command are different.
 
 ```
-karmadactl promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
+karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
 ```
 
 For more flags and example about the command, you can use `karmadactl promote --help`.

--- a/versioned_docs/version-v1.3/administrator/migration/promote-legacy-workload.md
+++ b/versioned_docs/version-v1.3/administrator/migration/promote-legacy-workload.md
@@ -28,7 +28,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          2m12s
 We can promote it to Karmada by executing the command below on the Karmada control plane.
 
 ```
-[root@master1]# karmadactl promote deployment nginx -n default -c member1
+[root@master1]# karmadactl promote deployment nginx -n default -C member1
 Resource "apps/v1, Resource=deployments"(default/nginx) is promoted successfully
 ```
 
@@ -52,7 +52,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          15m
 Most steps are same as those for clusters in `Push` mode. Only the flags of the `karmadactl promote` command are different.
 
 ```
-karmadactl promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
+karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
 ```
 
 For more flags and example about the command, you can use `karmadactl promote --help`.

--- a/versioned_docs/version-v1.4/administrator/migration/promote-legacy-workload.md
+++ b/versioned_docs/version-v1.4/administrator/migration/promote-legacy-workload.md
@@ -28,7 +28,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          2m12s
 We can promote it to Karmada by executing the command below on the Karmada control plane.
 
 ```
-[root@master1]# karmadactl promote deployment nginx -n default -c member1
+[root@master1]# karmadactl promote deployment nginx -n default -C member1
 Resource "apps/v1, Resource=deployments"(default/nginx) is promoted successfully
 ```
 
@@ -52,7 +52,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          15m
 Most steps are same as those for clusters in `Push` mode. Only the flags of the `karmadactl promote` command are different.
 
 ```
-karmadactl promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
+karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
 ```
 
 For more flags and example about the command, you can use `karmadactl promote --help`.

--- a/versioned_docs/version-v1.5/administrator/migration/promote-legacy-workload.md
+++ b/versioned_docs/version-v1.5/administrator/migration/promote-legacy-workload.md
@@ -28,7 +28,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          2m12s
 We can promote it to Karmada by executing the command below on the Karmada control plane.
 
 ```
-[root@master1]# karmadactl promote deployment nginx -n default -c member1
+[root@master1]# karmadactl promote deployment nginx -n default -C member1
 Resource "apps/v1, Resource=deployments"(default/nginx) is promoted successfully
 ```
 
@@ -52,7 +52,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          15m
 Most steps are same as those for clusters in `Push` mode. Only the flags of the `karmadactl promote` command are different.
 
 ```
-karmadactl promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
+karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
 ```
 
 For more flags and example about the command, you can use `karmadactl promote --help`.

--- a/versioned_docs/version-v1.6/administrator/migration/promote-legacy-workload.md
+++ b/versioned_docs/version-v1.6/administrator/migration/promote-legacy-workload.md
@@ -28,7 +28,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          2m12s
 We can promote it to Karmada by executing the command below on the Karmada control plane.
 
 ```
-[root@master1]# karmadactl promote deployment nginx -n default -c member1
+[root@master1]# karmadactl promote deployment nginx -n default -C member1
 Resource "apps/v1, Resource=deployments"(default/nginx) is promoted successfully
 ```
 
@@ -52,7 +52,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          15m
 Most steps are same as those for clusters in `Push` mode. Only the flags of the `karmadactl promote` command are different.
 
 ```
-karmadactl promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
+karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
 ```
 
 For more flags and example about the command, you can use `karmadactl promote --help`.

--- a/versioned_docs/version-v1.7/administrator/migration/promote-legacy-workload.md
+++ b/versioned_docs/version-v1.7/administrator/migration/promote-legacy-workload.md
@@ -28,7 +28,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          2m12s
 We can promote it to Karmada by executing the command below on the Karmada control plane.
 
 ```
-[root@master1]# karmadactl promote deployment nginx -n default -c member1
+[root@master1]# karmadactl promote deployment nginx -n default -C member1
 Resource "apps/v1, Resource=deployments"(default/nginx) is promoted successfully
 ```
 
@@ -52,7 +52,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          15m
 Most steps are same as those for clusters in `Push` mode. Only the flags of the `karmadactl promote` command are different.
 
 ```
-karmadactl promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
+karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
 ```
 
 For more flags and example about the command, you can use `karmadactl promote --help`.

--- a/versioned_docs/version-v1.8/administrator/migration/promote-legacy-workload.md
+++ b/versioned_docs/version-v1.8/administrator/migration/promote-legacy-workload.md
@@ -28,7 +28,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          2m12s
 We can promote it to Karmada by executing the command below on the Karmada control plane.
 
 ```
-[root@master1]# karmadactl promote deployment nginx -n default -c member1
+[root@master1]# karmadactl promote deployment nginx -n default -C member1
 Resource "apps/v1, Resource=deployments"(default/nginx) is promoted successfully
 ```
 
@@ -52,7 +52,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          15m
 Most steps are same as those for clusters in `Push` mode. Only the flags of the `karmadactl promote` command are different.
 
 ```
-karmadactl promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
+karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
 ```
 
 For more flags and example about the command, you can use `karmadactl promote --help`.

--- a/versioned_docs/version-v1.9/administrator/migration/promote-legacy-workload.md
+++ b/versioned_docs/version-v1.9/administrator/migration/promote-legacy-workload.md
@@ -28,7 +28,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          2m12s
 We can promote it to Karmada by executing the command below on the Karmada control plane.
 
 ```
-[root@master1]# karmadactl promote deployment nginx -n default -c member1
+[root@master1]# karmadactl promote deployment nginx -n default -C member1
 Resource "apps/v1, Resource=deployments"(default/nginx) is promoted successfully
 ```
 
@@ -52,7 +52,7 @@ nginx-6799fc88d8-sqjj4     1/1     Running     0          15m
 Most steps are same as those for clusters in `Push` mode. Only the flags of the `karmadactl promote` command are different.
 
 ```
-karmadactl promote deployment nginx -n default -c cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
+karmadactl promote deployment nginx -n default -C cluster1 --cluster-kubeconfig=<CLUSTER_KUBECONFIG_PATH>
 ```
 
 For more flags and example about the command, you can use `karmadactl promote --help`.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
typo error in https://karmada.io/docs/administrator/migration/promote-legacy-workload
follow the instructions to promote resource from member cluster
![image](https://github.com/user-attachments/assets/47d35097-eb99-40cc-a35e-2143f003660f)
some errors occured:
![image](https://github.com/user-attachments/assets/a595bc9e-1d8f-4335-8795-30bbb2475012)
the `-c member1` should be corrected as `-C member1`

It seems that the old versions of promote-legacy-workload still not right, so I rewrite the versioned documents.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


