### PR TITLE
Dockerfile: reduce karmada website container image size by 28%

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,35 @@
-FROM node:18-alpine
+# Stage 1: Build Stage.
+FROM node:18-alpine AS build
 
-# Set working directory
-WORKDIR /app/docs
+# Set working directory.
+WORKDIR /app
 
-# Copy package.json and package-lock.json to the container
+# Copy package.json and package-lock.json to the container.
 COPY package.json package-lock.json ./
 
-# Install dependencies
-RUN npm install
+# Install dependencies and browser-sync globally.
+RUN npm install && npm install -g browser-sync
 
-# Copy current directory to the container
+# Copy the rest of the application files.
 COPY . .
 
-# Set environment variable
+# Stage 2: Development Stage.
+FROM alpine:3.21.3
+
+# Install yarn in the final image required to run the application.
+RUN apk add --no-cache yarn
+
+# Set working directory.
+WORKDIR /app
+
+# Copy only necessary files from the build stage (node_modules and app files).
+COPY --from=build /app /app
+
+# Set environment variable.
 ENV NODE_ENV=development
 
-# Install browser-sync globally
-RUN npm install -g browser-sync
-
-# Expose port 3000
+# Expose port 3000.
 EXPOSE 3000
 
-# Start the application
+# Start the application using yarn.
 CMD ["yarn", "run", "start:watch"]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,6 @@
+[build]
+  command = "NODE_OPTIONS=\"--max_old_space_size=4096\" yarn run build"
+  publish = "build"
+
 [build.environment]
     NODE_VERSION = "18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4814,9 +4814,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001538",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
-      "integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==",
+      "version": "1.0.30001701",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
+      "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
       "funding": [
         {
           "type": "opencollective",
@@ -19086,9 +19086,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001538",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
-      "integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw=="
+      "version": "1.0.30001701",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
+      "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw=="
     },
     "ccount": {
       "version": "1.1.0",


### PR DESCRIPTION
**Description**

This commit optimizes the Karmada website's Docker container, reducing the image size from **~796MB to ~570MB**, achieving a significant **~28% reduction**.  

The size reduction was achieved by:  
- **Using a multi-stage build approach**: One stage for building the Node modules and another for running the server runtime.  
- **Consolidating `RUN` commands**: Combining multiple `RUN` operations to reduce intermediate tarball files generated during those operations.  


**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**Which issue(s) this PR fixes**:
N/A

**Special Notes for Reviewers**:  

- **Verification**:  
  This optimization can be verified by comparing Docker image builds before and after the changes:  
  ![Docker Optimization Before and After](https://github.com/user-attachments/assets/653940fd-1138-4d22-88f7-56e8afd8ddb0)  

- **Further Debugging**:  
  For deeper insights, the optimization can be analyzed using [dive](https://github.com/wagoodman/dive), a tool for exploring each layer in a Docker image. 