### PR TITLE
fixing typo in install-binary page

### DIFF
--- a/docs/installation/install-binary.md
+++ b/docs/installation/install-binary.md
@@ -941,7 +941,7 @@ systemctl start karmada-webhook.service
 systemctl status karmada-webhook.service
 ```
 
-### Configurate karmada-webhook
+### Configure karmada-webhook
 
 Download the `webhook-configuration.yaml` file: [https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml)
 

--- a/versioned_docs/version-v1.10/installation/install-binary.md
+++ b/versioned_docs/version-v1.10/installation/install-binary.md
@@ -941,7 +941,7 @@ systemctl start karmada-webhook.service
 systemctl status karmada-webhook.service
 ```
 
-### Configurate karmada-webhook
+### Configure karmada-webhook
 
 Download the `webhook-configuration.yaml` file: [https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml)
 

--- a/versioned_docs/version-v1.11/installation/install-binary.md
+++ b/versioned_docs/version-v1.11/installation/install-binary.md
@@ -941,7 +941,7 @@ systemctl start karmada-webhook.service
 systemctl status karmada-webhook.service
 ```
 
-### Configurate karmada-webhook
+### Configure karmada-webhook
 
 Download the `webhook-configuration.yaml` file: [https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml)
 

--- a/versioned_docs/version-v1.12/installation/install-binary.md
+++ b/versioned_docs/version-v1.12/installation/install-binary.md
@@ -941,7 +941,7 @@ systemctl start karmada-webhook.service
 systemctl status karmada-webhook.service
 ```
 
-### Configurate karmada-webhook
+### Configure karmada-webhook
 
 Download the `webhook-configuration.yaml` file: [https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml)
 

--- a/versioned_docs/version-v1.4/installation/install-binary.md
+++ b/versioned_docs/version-v1.4/installation/install-binary.md
@@ -942,7 +942,7 @@ systemctl start karmada-webhook.service
 systemctl status karmada-webhook.service
 ```
 
-### Configurate karmada-webhook
+### Configure karmada-webhook
 
 Download the `webhook-configuration.yaml` file: <https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml>
 

--- a/versioned_docs/version-v1.5/installation/install-binary.md
+++ b/versioned_docs/version-v1.5/installation/install-binary.md
@@ -941,7 +941,7 @@ systemctl start karmada-webhook.service
 systemctl status karmada-webhook.service
 ```
 
-### Configurate karmada-webhook
+### Configure karmada-webhook
 
 Download the `webhook-configuration.yaml` file: <https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml>
 

--- a/versioned_docs/version-v1.6/installation/install-binary.md
+++ b/versioned_docs/version-v1.6/installation/install-binary.md
@@ -941,7 +941,7 @@ systemctl start karmada-webhook.service
 systemctl status karmada-webhook.service
 ```
 
-### Configurate karmada-webhook
+### Configure karmada-webhook
 
 Download the `webhook-configuration.yaml` file: <https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml>
 

--- a/versioned_docs/version-v1.7/installation/install-binary.md
+++ b/versioned_docs/version-v1.7/installation/install-binary.md
@@ -941,7 +941,7 @@ systemctl start karmada-webhook.service
 systemctl status karmada-webhook.service
 ```
 
-### Configurate karmada-webhook
+### Configure karmada-webhook
 
 Download the `webhook-configuration.yaml` file: <https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml>
 

--- a/versioned_docs/version-v1.8/installation/install-binary.md
+++ b/versioned_docs/version-v1.8/installation/install-binary.md
@@ -941,7 +941,7 @@ systemctl start karmada-webhook.service
 systemctl status karmada-webhook.service
 ```
 
-### Configurate karmada-webhook
+### Configure karmada-webhook
 
 Download the `webhook-configuration.yaml` file: <https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml>
 

--- a/versioned_docs/version-v1.9/installation/install-binary.md
+++ b/versioned_docs/version-v1.9/installation/install-binary.md
@@ -941,7 +941,7 @@ systemctl start karmada-webhook.service
 systemctl status karmada-webhook.service
 ```
 
-### Configurate karmada-webhook
+### Configure karmada-webhook
 
 Download the `webhook-configuration.yaml` file: [https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/webhook-configuration.yaml)
 


### PR DESCRIPTION
This PR fixes a typographical error in multiple installation documentation files where "Configurate" was incorrectly used instead of "Configure".

Fixes #772

Affected files:
- docs/installation/install-binary.md
- versioned_docs/version-v1.4/installation/install-binary.md
- versioned_docs/version-v1.5/installation/install-binary.md
- versioned_docs/version-v1.6/installation/install-binary.md
- versioned_docs/version-v1.7/installation/install-binary.md
- versioned_docs/version-v1.8/installation/install-binary.md
- versioned_docs/version-v1.9/installation/install-binary.md
- versioned_docs/version-v1.10/installation/install-binary.md
- versioned_docs/version-v1.11/installation/install-binary.md
- versioned_docs/version-v1.12/installation/install-binary.md

Thank you for reviewing this PR!
