### PR TITLE
update cluster-registration.md to introduce how to unregister a cluster using the unregister command

### DIFF
--- a/docs/userguide/clustermanager/cluster-registration.md
+++ b/docs/userguide/clustermanager/cluster-registration.md
@@ -20,29 +20,29 @@ Each `karmada-agent` serves a cluster and takes responsibility for:
 
 ## Register cluster with 'Push' mode
 
-You can use the [kubectl-karmada](../../installation/install-cli-tools.md) CLI to `join` (register) and `unjoin` (unregister) clusters.
+You can use the [karmadactl](../../installation/install-cli-tools.md) CLI to `join` (register) and `unjoin` (unregister) clusters.
 
 ### Register cluster by CLI
 
 Join cluster with name `member1` to Karmada by using the following command.
-```
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
+```bash
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
 ```
 Repeat this step to join any additional clusters.
 
 The `--kubeconfig` specifies the Karmada's `kubeconfig` file and the CLI infers `karmada-apiserver` context
 from the `current-context` field of the `kubeconfig`. If there are more than one contexts configured in
 the `kubeconfig` file, it is recommended to specify the context by the `--karmada-context` flag. For example:
-```
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada --cluster-kubeconfig=<member1 kubeconfig>
+```bash
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada --cluster-kubeconfig=<member1 kubeconfig>
 ```
 
 The `--cluster-kubeconfig` specifies the member cluster's `kubeconfig` and the CLI infers the member cluster's context
 by the cluster name. If there are more than one contexts configured in the `kubeconfig` file, or you don't want to use
 the context name to register, it is recommended to specify the context by the `--cluster-context` flag. For example:
 
-```
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada \
+```bash
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=<karmada context> \
 --cluster-kubeconfig=<member1 kubeconfig> --cluster-context=member1
 ```
 > Note: The registering cluster name can be different from the context with `--cluster-context` specified.
@@ -50,7 +50,7 @@ kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --karmada-context
 ### Check cluster status
 
 Check the status of the joined clusters by using the following command.
-```
+```bash
 $ kubectl get clusters
 
 NAME      VERSION   MODE   READY   AGE
@@ -59,8 +59,8 @@ member1   v1.20.7   Push   True    66s
 ### Unregister cluster by CLI
 
 You can unjoin clusters by using the following command.
-```
-kubectl karmada unjoin member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
+```bash
+karmadactl unjoin member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
 ```
 During unjoin process, the resources propagated to `member1` by Karmada will be cleaned up.
 Also, the `--cluster-kubeconfig` is used to clean up the secret created at the `join` phase.
@@ -80,11 +80,11 @@ Be different from the `karmadactl join` which registers a cluster with `Push` mo
 
 In Karmada control plane, we can use `karmadactl token create` command to create bootstrap tokens whose default ttl is 24h.
 
-```
+```bash
 karmadactl token create --print-register-command --kubeconfig /etc/karmada/karmada-apiserver.config
 ```
 
-```
+```bash
 # The example output is shown below
 karmadactl register 10.10.x.x:32443 --token t2jgtm.9nybj0526mjw1jbf --discovery-token-ca-cert-hash sha256:f5a5a43869bb44577dba582e794c3e3750f2050d62f1b1dc80fd3d6a371b6ed4
 ```
@@ -96,11 +96,11 @@ For more details about `bootstrap token` please refer to:
 
 In the Kubernetes control plane of member clusters, we also need the `kubeconfig` file of the member cluster. Right after we execute the output of the `karmadactl register` command provided above.
 
-```
+```bash
 karmadactl register 10.10.x.x:32443 --token t2jgtm.9nybj0526mjw1jbf --discovery-token-ca-cert-hash sha256:f5a5a43869bb44577dba582e794c3e3750f2050d62f1b1dc80fd3d6a371b6ed4
 ```
 
-```
+```bash
 # The example output is shown below
 [preflight] Running pre-flight checks
 [prefligt] All pre-flight checks were passed
@@ -123,16 +123,16 @@ Once deployed, `the karmada-agent` will automatically register the cluster durin
 ### Check cluster status
 
 Check the status of the registered clusters by using the same command above.
-```
+```bash
 $ kubectl get clusters
 NAME      VERSION   MODE   READY   AGE
 member3   v1.20.7   Pull   True    66s
 ```
 ### Unregister cluster
 
-Undeploy the `karmada-agent` and then remove the `cluster` manually from Karmada.
-```
-kubectl delete cluster member3
+You can unregister pull mode member clusters by using the following command.
+```bash
+karmadactl unregister member3 --cluster-kubeconfig=<member3 kubeconfig> --cluster-context=<member3 context> --karmada-config=<karmada kubeconfig> --karmada-context=<karmada context>
 ```
 
 ## Cluster Identifier

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/clustermanager/cluster-registration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/clustermanager/cluster-registration.md
@@ -20,24 +20,24 @@ Karmada 控制平面不会直接访问成员集群，而是将其请求下放给
 
 ## 使用 'Push' 模式注册集群
 
-您可以使用 [kubectl-karmada](../../installation/install-cli-tools.md) 命令行工具来实现集群的 `join`（注册）和 `unjoin`（注销）操作。
+您可以使用 [karmadactl](../../installation/install-cli-tools.md) 命令行工具来实现集群的 `join`（注册）和 `unjoin`（注销）操作。
 
 ### 通过命令行工具注册集群
 
 使用以下命令将名为 `member1` 的集群注册到 Karmada 中。
 ```bash
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
 ```
 重复此步骤以注册任何其他集群。
 
 `--kubeconfig` 参数用于指定 Karmada 的 `kubeconfig` 文件，命令行工具可以从 `kubeconfig` 的 `current-context` 字段中推断出 `karmada-apiserver` 的上下文。如果 `kubeconfig` 文件中配置了多个上下文，建议通过 `--karmada-context` 参数明确指定上下文。例如：
 ```bash
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada --cluster-kubeconfig=<member1 kubeconfig>
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada --cluster-kubeconfig=<member1 kubeconfig>
 ```
 
 `--cluster-kubeconfig` 参数用于指定成员集群的 `kubeconfig` 文件，命令行工具可以根据集群名称推断出成员集群的上下文。如果 `kubeconfig` 文件中配置了多个上下文，或者您不想使用上下文名称进行注册时，建议通过 `--cluster-context` 参数明确指定上下文。例如：
 ```bash
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada \
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=<karmada context> \
 --cluster-kubeconfig=<member1 kubeconfig> --cluster-context=member1
 ```
 > 注意: 指定 `--cluster-context` 时，注册的集群名称可以与上下文名称不同。
@@ -56,7 +56,7 @@ member1   v1.20.7   Push   True    66s
 
 您可以使用以下命令注销集群。
 ```bash
-kubectl karmada unjoin member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
+karmadactl unjoin member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
 ```
 在注销过程中，Karmada 分发到 `member1` 的资源会被清理。
 并且，`--cluster-kubeconfig` 参数用于清理在 `join` 阶段创建的密钥。
@@ -70,7 +70,7 @@ kubectl karmada unjoin member1 --kubeconfig=<karmada kubeconfig> --cluster-kubec
 `karmadactl register` 命令用于以 PULL 模式将成员集群注册到 Karmada 控制平面。
 与采用 `Push` 模式注册集群的 `karmadactl join` 命令不同，`karmadactl register` 以 `Pull` 模式将集群注册到 Karmada 控制平面。
 
-> 注意：目前该功能仅支持通过 `karmadactl init` 安装的 Karmada 控制平面。
+> 注意: 使用此功能需要在 Karmada 控制面部署 ConfigMap `kube-public/cluster-info` 来暴露成员集群可访问的 Karmada Apiserver Server 以及根 CA。
 
 #### 在 Karmada 控制平面中创建引导令牌
 
@@ -126,9 +126,9 @@ member3   v1.20.7   Pull   True    66s
 
 ### 注销集群
 
-卸载 `karmada-agent`，然后手动从 Karmada 中移除 `cluster`。
+您可以使用以下命令注销集群。
 ```bash
-kubectl delete cluster member3
+karmadactl unregister member3 --cluster-kubeconfig=<member3 kubeconfig> --cluster-context=<member3 context> --karmada-config=<karmada kubeconfig> --karmada-context=<karmada context>
 ```
 
 ## 集群标识符

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.12/userguide/clustermanager/cluster-registration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.12/userguide/clustermanager/cluster-registration.md
@@ -20,24 +20,24 @@ Karmada 控制平面不会直接访问成员集群，而是将其请求下放给
 
 ## 使用 'Push' 模式注册集群
 
-您可以使用 [kubectl-karmada](../../installation/install-cli-tools.md) 命令行工具来实现集群的 `join`（注册）和 `unjoin`（注销）操作。
+您可以使用 [karmadactl](../../installation/install-cli-tools.md) 命令行工具来实现集群的 `join`（注册）和 `unjoin`（注销）操作。
 
 ### 通过命令行工具注册集群
 
 使用以下命令将名为 `member1` 的集群注册到 Karmada 中。
 ```bash
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
 ```
 重复此步骤以注册任何其他集群。
 
 `--kubeconfig` 参数用于指定 Karmada 的 `kubeconfig` 文件，命令行工具可以从 `kubeconfig` 的 `current-context` 字段中推断出 `karmada-apiserver` 的上下文。如果 `kubeconfig` 文件中配置了多个上下文，建议通过 `--karmada-context` 参数明确指定上下文。例如：
 ```bash
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada --cluster-kubeconfig=<member1 kubeconfig>
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada --cluster-kubeconfig=<member1 kubeconfig>
 ```
 
 `--cluster-kubeconfig` 参数用于指定成员集群的 `kubeconfig` 文件，命令行工具可以根据集群名称推断出成员集群的上下文。如果 `kubeconfig` 文件中配置了多个上下文，或者您不想使用上下文名称进行注册时，建议通过 `--cluster-context` 参数明确指定上下文。例如：
 ```bash
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada \
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=<karmada context> \
 --cluster-kubeconfig=<member1 kubeconfig> --cluster-context=member1
 ```
 > 注意: 指定 `--cluster-context` 时，注册的集群名称可以与上下文名称不同。
@@ -56,7 +56,7 @@ member1   v1.20.7   Push   True    66s
 
 您可以使用以下命令注销集群。
 ```bash
-kubectl karmada unjoin member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
+karmadactl unjoin member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
 ```
 在注销过程中，Karmada 分发到 `member1` 的资源会被清理。
 并且，`--cluster-kubeconfig` 参数用于清理在 `join` 阶段创建的密钥。
@@ -70,7 +70,7 @@ kubectl karmada unjoin member1 --kubeconfig=<karmada kubeconfig> --cluster-kubec
 `karmadactl register` 命令用于以 PULL 模式将成员集群注册到 Karmada 控制平面。
 与采用 `Push` 模式注册集群的 `karmadactl join` 命令不同，`karmadactl register` 以 `Pull` 模式将集群注册到 Karmada 控制平面。
 
-> 注意：目前该功能仅支持通过 `karmadactl init` 安装的 Karmada 控制平面。
+> 注意: 使用此功能需要在 Karmada 控制面部署 ConfigMap `kube-public/cluster-info` 来暴露成员集群可访问的 Karmada Apiserver Server 以及根 CA。
 
 #### 在 Karmada 控制平面中创建引导令牌
 
@@ -126,9 +126,9 @@ member3   v1.20.7   Pull   True    66s
 
 ### 注销集群
 
-卸载 `karmada-agent`，然后手动从 Karmada 中移除 `cluster`。
+您可以使用以下命令注销集群。
 ```bash
-kubectl delete cluster member3
+karmadactl unregister member3 --cluster-kubeconfig=<member3 kubeconfig> --cluster-context=<member3 context> --karmada-config=<karmada kubeconfig> --karmada-context=<karmada context>
 ```
 
 ## 集群标识符

--- a/versioned_docs/version-v1.12/userguide/clustermanager/cluster-registration.md
+++ b/versioned_docs/version-v1.12/userguide/clustermanager/cluster-registration.md
@@ -20,29 +20,29 @@ Each `karmada-agent` serves a cluster and takes responsibility for:
 
 ## Register cluster with 'Push' mode
 
-You can use the [kubectl-karmada](../../installation/install-cli-tools.md) CLI to `join` (register) and `unjoin` (unregister) clusters.
+You can use the [karmadactl](../../installation/install-cli-tools.md) CLI to `join` (register) and `unjoin` (unregister) clusters.
 
 ### Register cluster by CLI
 
 Join cluster with name `member1` to Karmada by using the following command.
-```
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
+```bash
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
 ```
 Repeat this step to join any additional clusters.
 
 The `--kubeconfig` specifies the Karmada's `kubeconfig` file and the CLI infers `karmada-apiserver` context
 from the `current-context` field of the `kubeconfig`. If there are more than one contexts configured in
 the `kubeconfig` file, it is recommended to specify the context by the `--karmada-context` flag. For example:
-```
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada --cluster-kubeconfig=<member1 kubeconfig>
+```bash
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada --cluster-kubeconfig=<member1 kubeconfig>
 ```
 
 The `--cluster-kubeconfig` specifies the member cluster's `kubeconfig` and the CLI infers the member cluster's context
 by the cluster name. If there are more than one contexts configured in the `kubeconfig` file, or you don't want to use
 the context name to register, it is recommended to specify the context by the `--cluster-context` flag. For example:
 
-```
-kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=karmada \
+```bash
+karmadactl join member1 --kubeconfig=<karmada kubeconfig> --karmada-context=<karmada context> \
 --cluster-kubeconfig=<member1 kubeconfig> --cluster-context=member1
 ```
 > Note: The registering cluster name can be different from the context with `--cluster-context` specified.
@@ -50,7 +50,7 @@ kubectl karmada join member1 --kubeconfig=<karmada kubeconfig> --karmada-context
 ### Check cluster status
 
 Check the status of the joined clusters by using the following command.
-```
+```bash
 $ kubectl get clusters
 
 NAME      VERSION   MODE   READY   AGE
@@ -59,8 +59,8 @@ member1   v1.20.7   Push   True    66s
 ### Unregister cluster by CLI
 
 You can unjoin clusters by using the following command.
-```
-kubectl karmada unjoin member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
+```bash
+karmadactl unjoin member1 --kubeconfig=<karmada kubeconfig> --cluster-kubeconfig=<member1 kubeconfig>
 ```
 During unjoin process, the resources propagated to `member1` by Karmada will be cleaned up.
 Also, the `--cluster-kubeconfig` is used to clean up the secret created at the `join` phase.
@@ -80,11 +80,11 @@ Be different from the `karmadactl join` which registers a cluster with `Push` mo
 
 In Karmada control plane, we can use `karmadactl token create` command to create bootstrap tokens whose default ttl is 24h.
 
-```
+```bash
 karmadactl token create --print-register-command --kubeconfig /etc/karmada/karmada-apiserver.config
 ```
 
-```
+```bash
 # The example output is shown below
 karmadactl register 10.10.x.x:32443 --token t2jgtm.9nybj0526mjw1jbf --discovery-token-ca-cert-hash sha256:f5a5a43869bb44577dba582e794c3e3750f2050d62f1b1dc80fd3d6a371b6ed4
 ```
@@ -96,7 +96,7 @@ For more details about `bootstrap token` please refer to:
 
 In the Kubernetes control plane of member clusters, we also need the `kubeconfig` file of the member cluster. Right after we execute the output of the `karmadactl register` command provided above.
 
-```
+```bash
 karmadactl register 10.10.x.x:32443 --token t2jgtm.9nybj0526mjw1jbf --discovery-token-ca-cert-hash sha256:f5a5a43869bb44577dba582e794c3e3750f2050d62f1b1dc80fd3d6a371b6ed4
 ```
 
@@ -123,16 +123,16 @@ Once deployed, `the karmada-agent` will automatically register the cluster durin
 ### Check cluster status
 
 Check the status of the registered clusters by using the same command above.
-```
+```bash
 $ kubectl get clusters
 NAME      VERSION   MODE   READY   AGE
 member3   v1.20.7   Pull   True    66s
 ```
 ### Unregister cluster
 
-Undeploy the `karmada-agent` and then remove the `cluster` manually from Karmada.
-```
-kubectl delete cluster member3
+You can unregister pull mode member clusters by using the following command.
+```bash
+karmadactl unregister member3 --cluster-kubeconfig=<member3 kubeconfig> --cluster-context=<member3 context> --karmada-config=<karmada kubeconfig> --karmada-context=<karmada context>
 ```
 
 ## Cluster Identifier


### PR DESCRIPTION

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Release v1.12 introduces a new command `unregister` to unregister pull mode member clusters. This pr updates `cluster-registration.md` to describe how to perform the process.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


