### PR TITLE
update install-binary.md to adjust the installation order

### DIFF
--- a/docs/installation/install-binary.md
+++ b/docs/installation/install-binary.md
@@ -673,6 +673,29 @@ livez check passed
 ###### karmada-aggregated-apiserver check success
 ```
 
+## Prepare Karmada CRDs Resources
+
+Execute operations at `karmada-01`.
+
+```bash
+git clone https://github.com/karmada-io/karmada
+cd karmada/charts/karmada/_crds/bases
+
+kubectl apply -f .
+
+cd ../patches/
+ca_string=$(cat /etc/karmada/pki/server-ca.crt | base64 | tr "\n" " "|sed s/[[:space:]]//g)
+sed -i "s/{{caBundle}}/${ca_string}/g" webhook_in_resourcebindings.yaml
+sed -i "s/{{caBundle}}/${ca_string}/g"  webhook_in_clusterresourcebindings.yaml
+# You need to change 172.31.209.245:4443 to your Load Balancer host:port.
+sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_resourcebindings.yaml
+sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_clusterresourcebindings.yaml
+
+kubectl patch CustomResourceDefinition resourcebindings.work.karmada.io --patch-file webhook_in_resourcebindings.yaml
+kubectl patch CustomResourceDefinition clusterresourcebindings.work.karmada.io --patch-file webhook_in_clusterresourcebindings.yaml
+cd ../../../../..
+```
+
 ## Install kube-controller-manager
 
 Execute operations at `karmada-01` `karmada-02` `karmada-03`.  Take `karmada-01` as an example.
@@ -964,26 +987,6 @@ ok
 ```
 
 ## Initialize Karmada
-
-Execute operations at `karmada-01`.
-
-```bash
-git clone https://github.com/karmada-io/karmada
-cd karmada/charts/karmada/_crds/bases
-
-kubectl apply -f .
-
-cd ../patches/
-ca_string=$(cat /etc/karmada/pki/server-ca.crt | base64 | tr "\n" " "|sed s/[[:space:]]//g)
-sed -i "s/{{caBundle}}/${ca_string}/g" webhook_in_resourcebindings.yaml
-sed -i "s/{{caBundle}}/${ca_string}/g"  webhook_in_clusterresourcebindings.yaml
-# You need to change 172.31.209.245:4443 to your Load Balancer host:port.
-sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_resourcebindings.yaml
-sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_clusterresourcebindings.yaml
-
-kubectl patch CustomResourceDefinition resourcebindings.work.karmada.io --patch-file webhook_in_resourcebindings.yaml
-kubectl patch CustomResourceDefinition clusterresourcebindings.work.karmada.io --patch-file webhook_in_clusterresourcebindings.yaml
-```
 
 Now, all the required components have been installed, and the member clusters could join Karmada control plane.
 If you want to use `karmadactl` to query, please run following command:

--- a/versioned_docs/version-v1.11/installation/install-binary.md
+++ b/versioned_docs/version-v1.11/installation/install-binary.md
@@ -673,6 +673,29 @@ livez check passed
 ###### karmada-aggregated-apiserver check success
 ```
 
+## Prepare Karmada CRDs Resources
+
+Execute operations at `karmada-01`.
+
+```bash
+git clone https://github.com/karmada-io/karmada
+cd karmada/charts/karmada/_crds/bases
+
+kubectl apply -f .
+
+cd ../patches/
+ca_string=$(cat /etc/karmada/pki/server-ca.crt | base64 | tr "\n" " "|sed s/[[:space:]]//g)
+sed -i "s/{{caBundle}}/${ca_string}/g" webhook_in_resourcebindings.yaml
+sed -i "s/{{caBundle}}/${ca_string}/g"  webhook_in_clusterresourcebindings.yaml
+# You need to change 172.31.209.245:4443 to your Load Balancer host:port.
+sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_resourcebindings.yaml
+sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_clusterresourcebindings.yaml
+
+kubectl patch CustomResourceDefinition resourcebindings.work.karmada.io --patch-file webhook_in_resourcebindings.yaml
+kubectl patch CustomResourceDefinition clusterresourcebindings.work.karmada.io --patch-file webhook_in_clusterresourcebindings.yaml
+cd ../../../../..
+```
+
 ## Install kube-controller-manager
 
 Execute operations at `karmada-01` `karmada-02` `karmada-03`.  Take `karmada-01` as an example.
@@ -964,26 +987,6 @@ ok
 ```
 
 ## Initialize Karmada
-
-Execute operations at `karmada-01`.
-
-```bash
-git clone https://github.com/karmada-io/karmada
-cd karmada/charts/karmada/_crds/bases
-
-kubectl apply -f .
-
-cd ../patches/
-ca_string=$(cat /etc/karmada/pki/server-ca.crt | base64 | tr "\n" " "|sed s/[[:space:]]//g)
-sed -i "s/{{caBundle}}/${ca_string}/g" webhook_in_resourcebindings.yaml
-sed -i "s/{{caBundle}}/${ca_string}/g"  webhook_in_clusterresourcebindings.yaml
-# You need to change 172.31.209.245:4443 to your Load Balancer host:port.
-sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_resourcebindings.yaml
-sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_clusterresourcebindings.yaml
-
-kubectl patch CustomResourceDefinition resourcebindings.work.karmada.io --patch-file webhook_in_resourcebindings.yaml
-kubectl patch CustomResourceDefinition clusterresourcebindings.work.karmada.io --patch-file webhook_in_clusterresourcebindings.yaml
-```
 
 Now, all the required components have been installed, and the member clusters could join Karmada control plane.
 If you want to use `karmadactl` to query, please run following command:

--- a/versioned_docs/version-v1.12/installation/install-binary.md
+++ b/versioned_docs/version-v1.12/installation/install-binary.md
@@ -673,6 +673,29 @@ livez check passed
 ###### karmada-aggregated-apiserver check success
 ```
 
+## Prepare Karmada CRDs Resources
+
+Execute operations at `karmada-01`.
+
+```bash
+git clone https://github.com/karmada-io/karmada
+cd karmada/charts/karmada/_crds/bases
+
+kubectl apply -f .
+
+cd ../patches/
+ca_string=$(cat /etc/karmada/pki/server-ca.crt | base64 | tr "\n" " "|sed s/[[:space:]]//g)
+sed -i "s/{{caBundle}}/${ca_string}/g" webhook_in_resourcebindings.yaml
+sed -i "s/{{caBundle}}/${ca_string}/g"  webhook_in_clusterresourcebindings.yaml
+# You need to change 172.31.209.245:4443 to your Load Balancer host:port.
+sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_resourcebindings.yaml
+sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_clusterresourcebindings.yaml
+
+kubectl patch CustomResourceDefinition resourcebindings.work.karmada.io --patch-file webhook_in_resourcebindings.yaml
+kubectl patch CustomResourceDefinition clusterresourcebindings.work.karmada.io --patch-file webhook_in_clusterresourcebindings.yaml
+cd ../../../../..
+```
+
 ## Install kube-controller-manager
 
 Execute operations at `karmada-01` `karmada-02` `karmada-03`.  Take `karmada-01` as an example.
@@ -964,26 +987,6 @@ ok
 ```
 
 ## Initialize Karmada
-
-Execute operations at `karmada-01`.
-
-```bash
-git clone https://github.com/karmada-io/karmada
-cd karmada/charts/karmada/_crds/bases
-
-kubectl apply -f .
-
-cd ../patches/
-ca_string=$(cat /etc/karmada/pki/server-ca.crt | base64 | tr "\n" " "|sed s/[[:space:]]//g)
-sed -i "s/{{caBundle}}/${ca_string}/g" webhook_in_resourcebindings.yaml
-sed -i "s/{{caBundle}}/${ca_string}/g"  webhook_in_clusterresourcebindings.yaml
-# You need to change 172.31.209.245:4443 to your Load Balancer host:port.
-sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_resourcebindings.yaml
-sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_clusterresourcebindings.yaml
-
-kubectl patch CustomResourceDefinition resourcebindings.work.karmada.io --patch-file webhook_in_resourcebindings.yaml
-kubectl patch CustomResourceDefinition clusterresourcebindings.work.karmada.io --patch-file webhook_in_clusterresourcebindings.yaml
-```
 
 Now, all the required components have been installed, and the member clusters could join Karmada control plane.
 If you want to use `karmadactl` to query, please run following command:

--- a/versioned_docs/version-v1.13/installation/install-binary.md
+++ b/versioned_docs/version-v1.13/installation/install-binary.md
@@ -673,6 +673,29 @@ livez check passed
 ###### karmada-aggregated-apiserver check success
 ```
 
+## Prepare Karmada CRDs Resources
+
+Execute operations at `karmada-01`.
+
+```bash
+git clone https://github.com/karmada-io/karmada
+cd karmada/charts/karmada/_crds/bases
+
+kubectl apply -f .
+
+cd ../patches/
+ca_string=$(cat /etc/karmada/pki/server-ca.crt | base64 | tr "\n" " "|sed s/[[:space:]]//g)
+sed -i "s/{{caBundle}}/${ca_string}/g" webhook_in_resourcebindings.yaml
+sed -i "s/{{caBundle}}/${ca_string}/g"  webhook_in_clusterresourcebindings.yaml
+# You need to change 172.31.209.245:4443 to your Load Balancer host:port.
+sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_resourcebindings.yaml
+sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_clusterresourcebindings.yaml
+
+kubectl patch CustomResourceDefinition resourcebindings.work.karmada.io --patch-file webhook_in_resourcebindings.yaml
+kubectl patch CustomResourceDefinition clusterresourcebindings.work.karmada.io --patch-file webhook_in_clusterresourcebindings.yaml
+cd ../../../../..
+```
+
 ## Install kube-controller-manager
 
 Execute operations at `karmada-01` `karmada-02` `karmada-03`.  Take `karmada-01` as an example.
@@ -964,26 +987,6 @@ ok
 ```
 
 ## Initialize Karmada
-
-Execute operations at `karmada-01`.
-
-```bash
-git clone https://github.com/karmada-io/karmada
-cd karmada/charts/karmada/_crds/bases
-
-kubectl apply -f .
-
-cd ../patches/
-ca_string=$(cat /etc/karmada/pki/server-ca.crt | base64 | tr "\n" " "|sed s/[[:space:]]//g)
-sed -i "s/{{caBundle}}/${ca_string}/g" webhook_in_resourcebindings.yaml
-sed -i "s/{{caBundle}}/${ca_string}/g"  webhook_in_clusterresourcebindings.yaml
-# You need to change 172.31.209.245:4443 to your Load Balancer host:port.
-sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_resourcebindings.yaml
-sed -i 's/karmada-webhook.karmada-system.svc:443/172.31.209.245:4443/g' webhook_in_clusterresourcebindings.yaml
-
-kubectl patch CustomResourceDefinition resourcebindings.work.karmada.io --patch-file webhook_in_resourcebindings.yaml
-kubectl patch CustomResourceDefinition clusterresourcebindings.work.karmada.io --patch-file webhook_in_clusterresourcebindings.yaml
-```
 
 Now, all the required components have been installed, and the member clusters could join Karmada control plane.
 If you want to use `karmadactl` to query, please run following command:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
In the `install-binary.md`, [initialize-karmada](https://karmada.io/docs/installation/install-binary#initialize-karmada) is used to create the CRDs required by Karmada. However, it is placed later in the installation sequence. The correct installation sequence should be to move it before the installation of the [karmada-controller-manager](https://karmada.io/docs/installation/install-binary#install-karmada-controller-manager).

**Which issue(s) this PR fixes**:
Fixes #https://github.com/karmada-io/karmada/issues/6186

**Special notes for your reviewer**:


