### PR TITLE
Fix syntax for referencing POD_IP

### DIFF
--- a/docs/administrator/security/security-considerations.md
+++ b/docs/administrator/security/security-considerations.md
@@ -94,5 +94,5 @@ spec:
               fieldPath: status.podIP
         command:
         - /bin/karmada-controller-manager
-        - --metrics-bind-address=${POD_IP}:8080
+        - --metrics-bind-address=$(POD_IP):8080
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/administrator/security/security-considerations.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/administrator/security/security-considerations.md
@@ -94,5 +94,5 @@ spec:
               fieldPath: status.podIP
         command:
         - /bin/karmada-controller-manager
-        - --metrics-bind-address=${POD_IP}:8080
+        - --metrics-bind-address=$(POD_IP):8080
 ```


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Replaced `${POD_IP}` with `$(POD_IP)` to properly reference the `POD_IP` from the environment variable.

**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/6266

**Special notes for your reviewer**:


