### PR TITLE
fix: Add description of storageClassesName option for karmadactl configuration

### DIFF
--- a/docs/reference/karmadactl/karmadactl-config.v1alpha1.md
+++ b/docs/reference/karmadactl/karmadactl-config.v1alpha1.md
@@ -73,6 +73,7 @@ Defines settings for deploying a local Etcd cluster as part of the Karmada contr
 - **`pvcSize`**: The size of the PersistentVolumeClaim used by Etcd when `storageMode` is set to `PVC`.
 - **`replicas`**: Number of Etcd replicas to deploy. For high availability, an odd number of replicas is recommended (e.g., 3, 5).
 - **`storageMode`**: Storage mode for Etcd data. Options are `emptyDir`, `hostPath`, or `PVC`.
+- **`storageClassesName`**: StorageClasses for PVC of Etcd data. If `storageMode` is set to `PVC`, you have to set `storageClassesName`.
 
 ```yaml
 spec:

--- a/versioned_docs/version-v1.12/reference/karmadactl/karmadactl-config.v1alpha1.md
+++ b/versioned_docs/version-v1.12/reference/karmadactl/karmadactl-config.v1alpha1.md
@@ -73,6 +73,7 @@ Defines settings for deploying a local Etcd cluster as part of the Karmada contr
 - **`pvcSize`**: The size of the PersistentVolumeClaim used by Etcd when `storageMode` is set to `PVC`.
 - **`replicas`**: Number of Etcd replicas to deploy. For high availability, an odd number of replicas is recommended (e.g., 3, 5).
 - **`storageMode`**: Storage mode for Etcd data. Options are `emptyDir`, `hostPath`, or `PVC`.
+- **`storageClassesName`**: StorageClasses for PVC of Etcd data. If `storageMode` is set to `PVC`, you have to set `storageClassesName`.
 
 ```yaml
 spec:

--- a/versioned_docs/version-v1.13/reference/karmadactl/karmadactl-config.v1alpha1.md
+++ b/versioned_docs/version-v1.13/reference/karmadactl/karmadactl-config.v1alpha1.md
@@ -73,6 +73,7 @@ Defines settings for deploying a local Etcd cluster as part of the Karmada contr
 - **`pvcSize`**: The size of the PersistentVolumeClaim used by Etcd when `storageMode` is set to `PVC`.
 - **`replicas`**: Number of Etcd replicas to deploy. For high availability, an odd number of replicas is recommended (e.g., 3, 5).
 - **`storageMode`**: Storage mode for Etcd data. Options are `emptyDir`, `hostPath`, or `PVC`.
+- **`storageClassesName`**: StorageClasses for PVC of Etcd data. If `storageMode` is set to `PVC`, you have to set `storageClassesName`.
 
 ```yaml
 spec:


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind documentation

**What this PR does / why we need it**:
When etcd storage mode is PVC, `storageClassesName` is not empty.  However, this is not written in Karmada docs.
This PR adds description for `storageClassesName`.

**Which issue(s) this PR fixes**:
Fixes # None

**Special notes for your reviewer**:


