### PR TITLE
fix wrong yaml format in karmada-v1.3 blog

### DIFF
--- a/blog/2022-09-06-karmada-v1.3/karmada-v1.3.md
+++ b/blog/2022-09-06-karmada-v1.3/karmada-v1.3.md
@@ -42,16 +42,16 @@ apiVersion: search.karmada.io/v1alpha1
 kind: ResourceRegistry
 metadata:
   name: proxy-sample
-  spec:
-    targetCluster:
-      clusterNames:
-      - member1
-      - member2
-      resourceSelectors:
-      - apiVersion: v1
-        kind: Pod
-      - apiVersion: v1
-        kind: Node
+spec:
+  targetCluster:
+    clusterNames:
+    - member1
+    - member2
+  resourceSelectors:
+  - apiVersion: v1
+    kind: Pod
+  - apiVersion: v1
+    kind: Node
 ```
 
 将该配置提交给karmada-apiserver之后，便可使用URL：`/apis/search.karmada.io/v1alpha1/proxying/karmada/proxy/api/v1/namespaces/default/pods`来进行集群资源访问。该URL中`/apis/search.karmada.io/v1alpha1/proxying/karmada/proxy`为固定前缀，后面部分与Kubernetes原生API路径完全一致。

--- a/i18n/zh/docusaurus-plugin-content-blog/2022-09-06-karmada-v1.3/karmada-v1.3.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/2022-09-06-karmada-v1.3/karmada-v1.3.md
@@ -42,16 +42,16 @@ apiVersion: search.karmada.io/v1alpha1
 kind: ResourceRegistry
 metadata:
   name: proxy-sample
-  spec:
-    targetCluster:
-      clusterNames:
-      - member1
-      - member2
-      resourceSelectors:
-      - apiVersion: v1
-        kind: Pod
-      - apiVersion: v1
-        kind: Node
+spec:
+  targetCluster:
+    clusterNames:
+    - member1
+    - member2
+  resourceSelectors:
+  - apiVersion: v1
+    kind: Pod
+  - apiVersion: v1
+    kind: Node
 ```
 
 将该配置提交给karmada-apiserver之后，便可使用URL：`/apis/search.karmada.io/v1alpha1/proxying/karmada/proxy/api/v1/namespaces/default/pods`来进行集群资源访问。该URL中`/apis/search.karmada.io/v1alpha1/proxying/karmada/proxy`为固定前缀，后面部分与Kubernetes原生API路径完全一致。


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When I directly copy the `ResourceRegistry` example yaml in the karmada-v1.3 blog and then apply it to the karmada, it failed, so I check the format yaml and update it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


