### PR TITLE
clarify supported file formats in karmadactl interpret doc

### DIFF
--- a/docs/reference/karmadactl/karmadactl-commands/karmadactl_create.md
+++ b/docs/reference/karmadactl/karmadactl-commands/karmadactl_create.md
@@ -8,7 +8,7 @@ Create a resource from a file or from stdin
 
 Create a resource from a file or from stdin.
 
- JSON and YAML formats are accepted.%!(EXTRA string=karmadactl)
+ JSON and YAML formats are accepted.
 
 ```
 karmadactl create -f FILENAME

--- a/docs/reference/karmadactl/karmadactl-commands/karmadactl_interpret.md
+++ b/docs/reference/karmadactl/karmadactl-commands/karmadactl_interpret.md
@@ -20,7 +20,7 @@ karmadactl interpret (-f FILENAME) (--operation OPERATION) [--ARGS VALUE]...
 
 ```
   # Check the customizations in file, both YAML and JSON formats are supported
-  karmadactl interpret -f customization.yml --check
+  karmadactl interpret -f customization.json --check
   
   # Execute the retention rule
   karmadactl interpret -f customization.yml --operation retain --desired-file desired.yml --observed-file observed.yml

--- a/docs/reference/karmadactl/karmadactl-commands/karmadactl_interpret.md
+++ b/docs/reference/karmadactl/karmadactl-commands/karmadactl_interpret.md
@@ -19,7 +19,7 @@ karmadactl interpret (-f FILENAME) (--operation OPERATION) [--ARGS VALUE]...
 ### Examples
 
 ```
-  # Check the customizations in file, both YAML and JSON formats are supported
+  # Check the customizations in file (only YAML and JSON formats are supported)
   karmadactl interpret -f customization.json --check
   
   # Execute the retention rule
@@ -58,7 +58,7 @@ karmadactl interpret (-f FILENAME) (--operation OPERATION) [--ARGS VALUE]...
       --desired-file string           Filename, directory, or URL to files identifying the resource to use as desiredObj argument in rule script.
       --desired-replica int32         The desiredReplica argument in rule script.
       --edit                          Edit customizations
-  -f, --filename strings              Filename, directory, or URL to files containing the customizations. Both YAML and JSON formats are supported.
+  -f, --filename strings              Filename, directory, or URL to files containing the customizations. File needs to be in either YAML or JSON format.
   -h, --help                          help for interpret
       --karmada-context string        The name of the kubeconfig context to use
       --kubeconfig string             Path to the kubeconfig file to use for CLI requests.

--- a/docs/reference/karmadactl/karmadactl-commands/karmadactl_interpret.md
+++ b/docs/reference/karmadactl/karmadactl-commands/karmadactl_interpret.md
@@ -19,8 +19,8 @@ karmadactl interpret (-f FILENAME) (--operation OPERATION) [--ARGS VALUE]...
 ### Examples
 
 ```
-  # Check the customizations in file
-  karmadactl interpret -f customization.json --check
+  # Check the customizations in file, both YAML and JSON formats are supported
+  karmadactl interpret -f customization.yml --check
   
   # Execute the retention rule
   karmadactl interpret -f customization.yml --operation retain --desired-file desired.yml --observed-file observed.yml
@@ -58,7 +58,7 @@ karmadactl interpret (-f FILENAME) (--operation OPERATION) [--ARGS VALUE]...
       --desired-file string           Filename, directory, or URL to files identifying the resource to use as desiredObj argument in rule script.
       --desired-replica int32         The desiredReplica argument in rule script.
       --edit                          Edit customizations
-  -f, --filename strings              Filename, directory, or URL to files containing the customizations
+  -f, --filename strings              Filename, directory, or URL to files containing the customizations. Both YAML and JSON formats are supported.
   -h, --help                          help for interpret
       --karmada-context string        The name of the kubeconfig context to use
       --kubeconfig string             Path to the kubeconfig file to use for CLI requests.


### PR DESCRIPTION

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Change file name to `customization.yml` in a `karmadactl interpret` example command to be uniform with other examples. Clarify that both YAML and JSON file formats are acceptable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


