### PR TITLE
add failover dynamic rate limit options

### DIFF
--- a/docs/userguide/failover/cluster-failover.md
+++ b/docs/userguide/failover/cluster-failover.md
@@ -136,6 +136,18 @@ JSONPath expressions follow the Kubernetes specification: <https://kubernetes.io
 
 **Note**: JSONPath expressions by default start searching from the "status" field of the API resource object. For example, to extract "availableReplicas" from a Deployment, the JSONPath expression should be `{.availableReplicas}` instead of `{.status.availableReplicas}`.
 
+### Configuring Eviction Rate Limiting
+
+In scenarios involving large-scale failures across multiple clusters, simultaneously evicting a large number of workloads can put immense pressure on the Karmada control plane and the remaining healthy clusters. To improve the stability and controllability of the failover process, Karmada introduces a rate limiting mechanism, allowing the eviction rate to be adjusted as needed via command-line parameters.
+
+You can fine-tune the eviction behavior by configuring the following command-line parameters on the `karmada-controller-manager` component:
+* `--resource-eviction-rate`:
+  Number of evictions per second. Default: **0.5**. When the value is 0, the acceleration speed will be set to run at a rate of 30 minutes per cycle.
+
+Examples:
+- If 12 workloads must be evicted and `--resource-eviction-rate=0.5`, Karmada evicts roughly one workload every 2 seconds and completes in about 24 seconds.
+- If set to `--resource-eviction-rate=2`, about 2 resources will be evicted per second, completing in roughly 6 seconds.
+
 :::note
 
 Cluster failover is still in continuous iteration. We are in the progress of gathering use cases. If you are interested in this feature, please feel free to start an enhancement issue to let us know.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/failover/cluster-failover.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/failover/cluster-failover.md
@@ -136,6 +136,19 @@ JSONPath 表达式遵循 Kubernetes 规范：<https://kubernetes.io/docs/referen
 
 **注意**：JSONPath 表达式默认从 API 资源对象的 "status" 字段开始查找。例如，若要提取 Deployment 的 "availableReplicas"，应使用 `{.availableReplicas}`，而不是 `{.status.availableReplicas}`。
 
+### 配置驱逐速率限制
+
+在集群故障的场景下，短时间内连续驱逐大量工作负载可能会对 Karmada 控制面以及剩余的健康集群造成巨大压力。为了提升故障迁移过程的稳定性和可控性，Karmada 引入了速率限制机制，可以根据需要通过命令行参数调整驱逐速率。
+
+用户可以通过在 `karmada-controller-manager` 组件上配置以下命令行参数，来精细化控制驱逐行为：
+
+* `--resource-eviction-rate`:
+  每秒驱逐的数量。默认值为 **0.5**。设置为 0 时驱逐速率会以 30 分钟一个的速度进行。
+
+示例：
+- 假设需要驱逐 12 个工作负载，设置 `--resource-eviction-rate=0.5` 时，大约每 2 秒驱逐 1 个，约 24 秒完成全部驱逐。
+- 若设置为 `--resource-eviction-rate=2`，则大约每秒驱逐 2 个，约 6 秒完成。
+
 :::note
 
 集群故障迁移特性仍在持续迭代中，欢迎大家反馈实际使用场景。如果您对该特性感兴趣，欢迎提交增强 issue 与我们交流。


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note
`karmada-controller-manager`: Introduced `--resource-eviction-rate` flag to specify the eviction rate during cluster failover.
```

