### PR TITLE
docs: translate Resource Propagating doc to Chinese

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/scheduling/resource-propagating.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/scheduling/resource-propagating.md
@@ -1,21 +1,22 @@
 ---
-title: Resource Propagating
+title: 资源分发
 ---
 
-The [PropagationPolicy](https://github.com/karmada-io/karmada/blob/master/pkg/apis/policy/v1alpha1/propagation_types.go#L13) and [ClusterPropagationPolicy](https://github.com/karmada-io/karmada/blob/master/pkg/apis/policy/v1alpha1/propagation_types.go#L292) APIs are provided to propagate resources. For the differences between the two APIs, please see [here](../../faq/faq.md#what-is-the-difference-between-propagationpolicy-and-clusterpropagationpolicy).
+Karmada 提供了 [PropagationPolicy](https://github.com/karmada-io/karmada/blob/master/pkg/apis/policy/v1alpha1/propagation_types.go#L13) 和 [ClusterPropagationPolicy](https://github.com/karmada-io/karmada/blob/master/pkg/apis/policy/v1alpha1/propagation_types.go#L292) 两种 API 用于资源分发。关于这两种 API 的区别，可参考 [此处](../../faq/faq.md#what-is-the-difference-between-propagationpolicy-and-clusterpropagationpolicy)。
 
-Here, we use PropagationPolicy as an example to describe how to propagate resources.
+本文将以 PropagationPolicy 为例，介绍资源分发的具体操作方法。
 
-## Before you start
+## 前提条件
 
-[Install Karmada](../../installation/installation.md) and prepare the [karmadactl command-line](../../installation/install-cli-tools.md) tool.
+请先 [安装 Karmada](../../installation/installation.md)，并准备好 [karmadactl 命令行工具](../../installation/install-cli-tools.md)。
 
-## Deploy a simplest multi-cluster Deployment
+> 注意：在此之前，我们需要将 kubectl 指向 `<karmada-apiserver.config>`，而不是成员集群。
 
-### Create a PropagationPolicy object
+## 部署最简单的多集群 Deployment
 
-You can propagate a Deployment by creating a PropagationPolicy object defined in a YAML file. For example, this YAML
-file describes a Deployment object named nginx under default namespace need to be propagated to member1 cluster:
+### 创建 PropagationPolicy 对象
+
+可通过创建 YAML 文件定义的 PropagationPolicy 对象来分发 Deployment 资源。例如，以下 YAML 文件描述了：需将 default 命名空间下名为 nginx 的 Deployment 对象分发到 member1 集群：
 
 ```yaml
 # propagationpolicy.yaml
@@ -34,41 +35,41 @@ spec:
         - member1
 ```
 
-1. Create a propagationPolicy base on the YAML file:
+1. 基于上述 YAML 文件创建分发策略:
 ```shell
 kubectl apply -f propagationpolicy.yaml
 ```
-2. Create a Deployment nginx resource:
+2. 创建名为 nginx 的 Deployment:
 ```shell
 kubectl create deployment nginx --image nginx
 ```
-> Note: The resource exists only as a template in karmada. After being propagated to a member cluster, the behavior of the resource is the same as that of a single kubernetes cluster.
+> 注意：该资源在 Karmada 中仅作为模板存在；分发到成员集群后，其行为与单 Kubernetes 集群中的资源行为一致。
+> 
+> 注意：资源与分发策略的创建无先后顺序要求。
 
-> Note: Resources and PropagationPolicy are created in no sequence.
-
-3. Display information of the deployment:
+3. 查看 Deployment 的分发状态:
 ```shell
 karmadactl get deployment
 ```
-The output is similar to this:
+输出结果示例如下：
 ```shell
 NAME    CLUSTER   READY   UP-TO-DATE   AVAILABLE   AGE   ADOPTION
 nginx   member1   1/1     1            1           52s   Y
 ```
 
-4. List the pods created by the deployment:
+4. 查看该 Deployment 在成员集群中创建的 Pod:
 ```shell
 karmadactl get pod -l app=nginx
 ```
-The output is similar to this:
+输出结果示例如下：
 ```shell
 NAME                     CLUSTER   READY   STATUS    RESTARTS   AGE
 nginx-6799fc88d8-s7vv9   member1   1/1     Running   0          52s
 ```
 
-### Update PropagationPolicy
+### 更新分发策略
 
-You can update the propagationPolicy by applying a new YAML file. This YAML file propagates the Deployment to the member2 cluster.
+可通过应用新的 YAML 文件来更新分发策略。例如，以下 YAML 文件将 nginx Deployment 的分发目标修改为 member2 集群：
 
 ```yaml
 # propagationpolicy-update.yaml
@@ -87,64 +88,66 @@ spec:
         - member2
 ```
 
-1. Apply the new YAML file:
+1. 应用更新后的 YAML 文件:
 ```shell
 kubectl apply -f propagationpolicy-update.yaml
 ```
-2. Display information of the deployment (the output is similar to this):
+2. 更新后，查看 Deployment 信息（输出示例如下）:
 ```shell
 NAME    CLUSTER   READY   UP-TO-DATE   AVAILABLE   AGE   ADOPTION
 nginx   member2   1/1     1            1           5s    Y
 ```
-3. List the pods of the deployment (the output is similar to this):
+3. 查看更新后 Deployment 对应的 Pod（输出示例如下）:
 ```shell
 NAME                     CLUSTER   READY   STATUS    RESTARTS   AGE
 nginx-6799fc88d8-8t8cc   member2   1/1     Running   0          17s
 ```
 
-### Update Deployment
+### 更新 Deployment
 
-You can update the deployment template. The changes will be automatically synchronized to the member clusters.
+可直接更新 Karmada 中的 Deployment 模板，修改会自动同步到所有成员集群。
 
-1. Update deployment replicas to 2
-2. Display information of the deployment (the output is similar to this):
+1. 将 Deployment 的副本数（replicas）更新为 2
+2. 更新后查看 Deployment 信息（输出示例如下）:
 ```shell
 NAME    CLUSTER   READY   UP-TO-DATE   AVAILABLE   AGE     ADOPTION
 nginx   member2   2/2     2            2           7m59s   Y
 ```
-3. List the pods of the deployment (the output is similar to this):
+3. 查看更新副本数后对应的 Pod（输出示例如下）:
 ```shell
 NAME                     CLUSTER   READY   STATUS    RESTARTS   AGE
 nginx-6799fc88d8-8t8cc   member2   1/1     Running   0          8m12s
 nginx-6799fc88d8-zpl4j   member2   1/1     Running   0          17s
 ```
 
-### Delete a propagationPolicy
+### 删除分发策略
 
-Delete the propagationPolicy by name:
+通过名称删除分发策略:
 ```shell
 kubectl delete propagationpolicy example-policy
 ```
-Deleting a propagationPolicy does not delete deployments propagated to member clusters. You need to delete deployments in the karmada control-plane:
+> 删除分发策略不会删除已分发到成员集群的 Deployment，需单独在 Karmada 控制平面中删除 Deployment。
+
+在 Karmada 控制平面中删除 nginx Deployment：
 ```shell
 kubectl delete deployment nginx
 ```
 
-## Deploy deployment into a specified set of target clusters
+## 将 Deployment 部署到指定的目标集群集合
 
-`.spec.placement.clusterAffinity` field of PropagationPolicy represents scheduling restrictions on a certain set of clusters, without which any cluster can be scheduling candidates.
+`PropagationPolicy` 的 `.spec.placement.clusterAffinity` 字段用于定义集群调度约束；若不配置该字段，所有集群均会成为调度候选。
 
-It has four fields to set:
-- LabelSelector
-- FieldSelector
-- ClusterNames
-- ExcludeClusters
+该字段支持以下 4 种配置方式：
+- LabelSelector（标签选择器）
+- FieldSelector（字段选择器）
+- ClusterNames（集群名称列表）
+- ExcludeClusters（排除集群列表）
 
-### LabelSelector
+###  LabelSelector（标签选择器）
 
-LabelSelector is a filter to select member clusters by labels. It uses `*metav1.LabelSelector` type. If it is non-nil and non-empty, only the clusters match this filter will be selected.
+通过集群标签筛选目标成员集群，使用 `*metav1.LabelSelector` 类型。若配置非空的标签选择器，仅匹配标签的集群会被选中。
 
-PropagationPolicy can be configured as follows:
+配置方式 1：精确匹配标签:
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -161,7 +164,7 @@ spec:
     #...
 ```
 
-PropagationPolicy can also be configured as follows:
+配置方式 2：表达式匹配标签:
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -180,14 +183,13 @@ spec:
           - us
     #...
 ```
+关于 `matchLabels` 和 `matchExpressions` 的详细说明，可参考[支持集合型需求的资源文档](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements)。
 
-For a description of `matchLabels` and `matchExpressions`, you can refer to [Resources that support set-based requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
+### FieldSelector（字段选择器）
 
-### FieldSelector
+通过集群字段筛选目标成员集群。若配置非空的字段选择器，仅匹配字段的集群会被选中。
 
-FieldSelector is a filter to select member clusters by fields. If it is non-nil and non-empty, only the clusters match this filter will be selected.
-
-PropagationPolicy can be configured as follows:
+配置示例
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -211,17 +213,17 @@ spec:
     #...
 ```
 
-If multiple `matchExpressions` are specified in the `fieldSelector`, the cluster must match all `matchExpressions`.
+字段选择器规则
 
-The `key` in `matchExpressions` now supports three values: `provider`, `region`, and `zone`, which correspond to the `.spec.provider`, `.spec.region`, and `.spec.zone` fields of the Cluster object, respectively.
+- 若 `fieldSelector` 中指定多个 `matchExpressions`，集群需满足所有表达式才能被选中。
+- `matchExpressions` 中的 `key` 目前支持 3 个值：`provider`（对应 Cluster 对象的 `.spec.provider` 字段）、`region`（对应 `.spec.region`）、`zone`（对应 `.spec.zone`）。
+- `matchExpressions` 中的 `operator` 目前支持 `In`（在列表内）和 `NotIn`（不在列表内）。
 
-The `operator` in `matchExpressions` now supports `In` and `NotIn`.
+### ClusterNames（集群名称列表）
 
-### ClusterNames
+用户可以直接指定目标集群的名称。
 
-Users can set the `ClusterNames` field to specify the selected clusters.
-
-PropagationPolicy can be configured as follows:
+配置示例如下:
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -238,11 +240,11 @@ spec:
     #...
 ```
 
-### ExcludeClusters
+### ExcludeClusters（排除集群列表）
 
-Users can set the `ExcludeClusters` fields to specify the clusters to be ignored.
+用户可以通过设置 `ExcludeClusters` 字段来指定需要忽略的集群。
 
-PropagationPolicy can be configured as follows:
+分发策略（PropagationPolicy）可按如下方式配置:
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -259,21 +261,22 @@ spec:
     #...
 ```
 
-## Multiple cluster affinity groups
+## 多集群亲和性组
 
-Users can set the ClusterAffinities field and declare multiple cluster groups in PropagationPolicy. The scheduler will evaluate these groups one by one in the order they appear in the spec, the group that does not satisfy scheduling restrictions will be ignored which means all clusters in this group will not be selected unless it also belongs to the next group(a cluster cloud belong to multiple groups).
+用户可通过设置 ClusterAffinities 字段，在分发策略（PropagationPolicy）中声明多个集群组。调度器会按照配置在 spec 中的顺序，逐一评估这些集群组：
 
-If none of the groups satisfy the scheduling restrictions, the scheduling fails, which means no cluster will be selected.
+- 不满足调度约束的集群组会被忽略（即该组内所有集群均不会被选中，除非集群同时属于下一个集群组 —— 一个集群可归属多个组）。
+- 若所有集群组均不满足调度约束，调度会失败（无任何集群被选中）。
 
-Note:
+注意事项
 
-1. ClusterAffinities can not co-exist with ClusterAffinity.
-2. If both ClusterAffinity and ClusterAffinities are not set, any cluster can be scheduling candidates.
+1. `ClusterAffinities`（多集群亲和性组）与 `ClusterAffinity`（单集群亲和性）不可同时配置。
+2. 若未配置 ClusterAffinity 和 ClusterAffinities，则所有集群均会成为调度候选集群。
 
-Potential use case 1:
-The private clusters in the local data center could be the main group, and the managed clusters provided by cluster providers could be the secondary group. So that the Karmada scheduler would prefer to schedule workloads to the main group and the second group will only be considered in case of the main group does not satisfy restrictions(like, lack of resources).
+潜在应用场景1:
+可将本地数据中心的私有集群设为主集群组，将云服务商提供的托管集群设为副集群组。这样，Karmada 调度器会优先将工作负载调度到主集群组；仅当主集群组不满足约束（如资源不足）时，才会考虑副集群组。
 
-PropagationPolicy can be configured as follows:
+分发策略可按如下配置：
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -295,9 +298,10 @@ spec:
     #...
 ```
 
-Potential use case 2: For the disaster recovery scenario, the clusters could be organized to primary and backup groups, the workloads would be scheduled to primary clusters firstly, and when primary cluster fails(like data center power off), Karmada scheduler could migrate workloads to the backup clusters.
+潜在应用场景2: 
+可将集群划分为主集群组和备集群组，工作负载会优先调度到主集群；当主集群发生故障（如数据中心断电）时，Karmada 调度器可将工作负载迁移到备集群。
 
-PropagationPolicy can be configured as follows:
+分发策略可按如下配置：
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -318,15 +322,17 @@ spec:
     #...
 ```
 
-For more detailed design information, please refer to [Multiple scheduling group](https://github.com/karmada-io/karmada/tree/master/docs/proposals/scheduling/multi-scheduling-group).
+如需了解更详细的设计信息，可参考 [多调度组 文档](https://github.com/karmada-io/karmada/tree/master/docs/proposals/scheduling/multi-scheduling-group)。
 
-## Schedule based on Taints and Tolerations
+## 基于污点和容忍的调度
 
-`.spec.placement.clusterTolerations` field of PropagationPolicy represents the tolerations. Like kubernetes, tolerations need to be used in conjunction with taints on the clusters.
-After setting one or more taints on the cluster, workloads cannot be scheduled or run on these clusters unless the policy explicitly states that these taints are tolerated.
-Karmada currently supports taints whose effects are `NoSchedule` and `NoExecute`.
+分发策略（PropagationPolicy）的 `.spec.placement.clusterTolerations` 字段用于定义集群容忍规则。与 Kubernetes 类似，容忍规则需与集群上设置的 “污点” 配合使用：
+- 若为集群设置了一个或多个污点，默认情况下工作负载无法调度或运行在这些集群上。
+- 仅当分发策略明确声明 “容忍” 这些污点时，工作负载才能被调度到对应集群。
 
-You can `karmadactl taint` to taint a cluster:
+目前 Karmada 支持的污点效应（effect）包括 `NoSchedule`（不调度，仅影响新工作负载）和 `NoExecute`（不执行，既影响已运行工作负载，也影响新工作负载）。
+
+你可以通过 `karmadactl taint` 命令为集群添加污点:
 
 ```shell
 # Update cluster 'foo' with a taint with key 'dedicated' and value 'special-user' and effect 'NoSchedule'
@@ -334,7 +340,7 @@ You can `karmadactl taint` to taint a cluster:
 karmadactl taint clusters foo dedicated=special-user:NoSchedule
 ```
 
-In order to schedule to the above cluster, you need to declare the following in the Policy:
+若需将工作负载调度到上述带污点的集群（如 foo 集群），需在分发策略中声明对应的容忍规则，示例如下：
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -350,13 +356,13 @@ spec:
       Effect: NoSchedule 
 ```
 
-`NoExecute` taints are also used in `Multi-cluster Failover`. See details [here](../failover/failover-analysis.md).
+NoExecute 类型的污点还可用于 “多集群故障转移” 场景，详情可参考 [此处](../failover/failover-analysis.md)。
 
-## Multi region HA support
+## 多区域高可用支持
 
-By leveraging the spread-by-region constraint, users are able to deploy workloads aross regions, e.g. people may want their workloads always running on different regions for HA purposes.
+通过 “按区域扩散约束”（spread-by-region constraint），用户可将工作负载部署到多个区域。例如，为实现高可用（HA），用户可能希望工作负载始终在不同区域运行。
 
-To enable multi region deployment, you should use the command below to customize the region of clusters.
+要实现多区域部署，需先通过以下命令自定义集群的区域配置：
 
 ```shell
 $ kubectl --kubeconfig ~/.kube/karmada.config --context karmada-apiserver edit cluster/member1
@@ -372,7 +378,7 @@ spec:
 ...
 ```
 
-Then you need to restrict the maximum and minimum number of cluster groups to be selected. Assume there are two regions, you may want to deploy the workload in one cluster per region. You can refer to:
+之后，需限制待选中的集群组数量（最大值和最小值）。假设存在两个区域，且希望在每个区域各选择一个集群部署工作负载，可参考以下配置：
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -395,28 +401,29 @@ spec:
 
 :::note
 
-If the replica division preference is `StaticWeightList`, the declaration specified by spread constraints will be ignored.
-If one of spread constraints are using `SpreadByField`, the `SpreadByFieldCluster` must be included.
-For example, when using `SpreadByFieldRegion` to specify region groups, at the meantime, you must use
-`SpreadByFieldCluster` to specify how many clusters should be selected.
+若副本分割偏好（`ReplicaDivisionPreference`）设为 `StaticWeightList`（静态权重列表），则扩散约束的声明会被忽略。
+若扩散约束中使用了 `SpreadByField`（按字段扩散），则必须包含 `SpreadByFieldCluster`（按集群扩散）。
+例如，当使用 `SpreadByFieldRegion`（按区域扩散）指定区域组时，需同时通过 `SpreadByFieldCluster` 指定每个区域应选中的集群数量。
 
 :::
 
-## Multiple strategies of replica Scheduling
+## 副本调度的多种策略
 
-`.spec.placement.replicaScheduling` represents the scheduling policy on dealing with the number of replicas when propagating resources that have replicas in spec (e.g. deployments, statefulsets and CRDs which can be interpreted by [Customizing Resource Interpreter](../globalview/customizing-resource-interpreter.md)) to member clusters.
+当分发 “spec 字段中包含副本数配置的资源”（如 Deployment、StatefulSet，或可通过[自定义资源解释器](../globalview/customizing-resource-interpreter.md)解析的 CRD）到成员集群时，`.spec.placement.replicaScheduling` 字段用于定义副本数的调度策略。
 
-It has two replicaSchedulingTypes which determines how the replicas is scheduled when Karmada propagating a resource:
+该字段包含两种 “副本调度类型”（`replicaSchedulingType`），决定 Karmada 分发资源时副本的分配方式：
 
-* `Duplicated`: duplicate the same replicas to each candidate member cluster from resources.
-* `Divided`: divide replicas into parts according to numbers of valid candidate member clusters, and exact replicas for each cluster are determined by `ReplicaDivisionPreference`.
+* `Duplicated（复制式）`：将资源的副本数 “复制” 到每个候选成员集群。例如，资源副本数为 2，若选中 3 个集群，则每个集群均部署 2 个副本。
+* `Divided（分割式）`：将资源的副本数 “分割” 到多个候选成员集群，总副本数保持不变。例如，资源副本数为 6，若选中 3 个集群，则 6 个副本会按规则分配到这 3 个集群（具体分配逻辑由 `ReplicaDivisionPreference` 决定）。
 
-`ReplicaDivisionPreference` determines the replicas is divided when ReplicaSchedulingType is `Divided`.
+副本分割偏好（ReplicaDivisionPreference）仅当 `replicaSchedulingType` 设为 `Divided`（分割式）时生效，用于决定副本的具体分割规则，支持以下两种类型：
 
-* `Aggregated`: divide replicas into clusters as few as possible, while respecting clusters' resource availabilities during the division. See details in [Schedule based on Cluster Resource Modeling](./cluster-resources.md).
-* `Weighted`: divide replicas by weight according to `WeightPreference`. There are two kinds of `WeightPreference` to set. `StaticWeightList` statically allocates replicas to target clusters based on weight. Target clusters can be selected by `ClusterAffinity`. `DynamicWeight` specifies the factor to generate the dynamic weight list. If specified, `StaticWeightList` will be ignored. Karmada currently supports the factor `AvailableReplicas`.
+* `Aggregated`（聚合式）：在尊重集群资源可用性（如剩余 CPU、内存）的前提下，将副本尽可能分配到少量集群中。详情可参考[基于集群资源建模的调度](./cluster-resources.md)。
+* `Weighted`（加权式）：按权重分配副本，需通过 WeightPreference（权重偏好）配置具体规则，支持两种权重配置方式：
+  1. `StaticWeightList`（静态权重列表）：基于预设权重将副本分配到目标集群，目标集群可通过 ClusterAffinity（集群亲和性）筛选。
+  2. `DynamicWeight`（动态权重）：基于动态因子生成权重列表。若配置动态权重，`StaticWeightList` 会被忽略。目前 Karmada 支持的动态因子为 `AvailableReplicas`（集群可用副本数，即集群剩余资源可支撑的最大副本数）。
 
-The following gives two simple examples:
+下面给出两个配置示例：
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -441,7 +448,7 @@ spec:
             weight: 1
 ```
 
-It means replicas will be evenly propagated to member1 and member2.
+上述配置表示：副本会均匀分配到 `member1` 和 `member2` 集群（权重均为 1，各分配 50% 副本）。
 
 ```yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -458,28 +465,29 @@ spec:
         dynamicWeight: AvailableReplicas 
 ```
 
-It means replicas will be propagated based on available replicas in member clusters. For example, the scheduler selected 3 cluster(A/B/C) and should divide 12 replicas to them.
-Based on cluster resource modeling, we get that the max available replica of A, B, C is 6, 12, 18.
-Therefore, the weight of cluster A:B:C will be 6:12:18 (equal to 1:2:3). At last, the assignment would be "A: 2, B: 4, C: 6".
+上述配置表示：副本会基于成员集群的 “可用副本数” 动态分配。例如：
+1. 调度器选中 3 个集群（A、B、C），需分配的总副本数为 12。
+2. 通过集群资源建模得知，A、B、C 的可用副本数分别为 6、12、18。
+3. 权重比例计算为 6:12:18 = 1:2:3。
+4. 最终副本分配结果：A 集群 2 个（12×1/6）、B 集群 4 个（12×2/6）、C 集群 6 个（12×3/6）。
 
 :::note
 
-If `ReplicaDivisionPreference` is set to `Weighted` and `WeightPreference` is not set, the default strategy is to weight all clusters averagely.
+若 `ReplicaDivisionPreference` 设为 `Weighted`（加权式），但未配置 `WeightPreference`（权重偏好），则默认策略为 “所有集群平均加权”（即每个集群权重相同）。
 
 :::
 
-## Configure PropagationPolicy/ClusterPropagationPolicy priority
-If a PropagationPolicy and a ClusterPropagationPolicy match the workload, Karmada will select the PropagationPolicy.
-If multiple PropagationPolicies match the workload, Karmada will select the one with the highest priority. A PropagationPolicy supports implicit and explicit priorities.
-The same goes for ClusterPropagationPolicy.
+## 配置分发策略 / 集群级分发策略优先级
+当一个工作负载同时匹配 “分发策略（PropagationPolicy）” 和 “集群级分发策略（ClusterPropagationPolicy）” 时，Karmada 会优先选择 PropagationPolicy（命名空间级策略）。
+若多个 PropagationPolicy 匹配同一工作负载，Karmada 会选择优先级最高的策略；ClusterPropagationPolicy 的优先级规则与此完全一致。
 
-The following takes PropagationPolicy as an example.
+以下以 PropagationPolicy 为例，说明优先级配置规则。
 
-### Configure explicit priority
-The `spec.priority` in a PropagationPolicy represents the explicit priority. A greater value means a higher priority.
-> Note: If not specified, defaults to 0.
+### 配置显式优先级（Explicit Priority）
+PropagationPolicy 的 `spec.priority` 字段用于配置显式优先级，数值越大，优先级越高。
+> 注意：若未配置该字段，默认优先级为 0。
 
-Assume there are multiple policies:
+假设有以下 3 个 PropagationPolicy：
 ```yaml
 # highexplicitpriority.yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -534,15 +542,15 @@ spec:
       clusterNames:
         - member3
 ```
-The `nginx` deployment in `default` namespace will be propagated to cluster `member1`.
+此时，`default` 命名空间下的 `nginx` Deployment 会匹配优先级最高的策略（priority=2），最终分发到 `member1` 集群。
 
-### Configure implicit priority
-The `spec.resourceSelectors` in a PropagationPolicy represents the implicit priority. The priority order (from low to high) is as follows:
-* The PropagationPolicy resourceSelector whose name and labelSelector are empty matches the workload.
-* The labelSelector of PropagationPolicy resourceSelector matches the workload.
-* The name of PropagationPolicy resourceSelector matches the workload.
+### 配置隐式优先级
+分发策略（PropagationPolicy）的 `spec.resourceSelectors`（资源选择器）决定了隐式优先级，优先级从低到高排序如下：
+1. 资源选择器的 `name` 和 `labelSelector` 均为空（匹配同一资源类型的所有工作负载）；
+2. 资源选择器的 `labelSelector` 非空（通过标签匹配工作负载）；
+3. 资源选择器的 `name` 非空（通过名称精确匹配工作负载）。
 
-Assume there are multiple policies:
+假设有以下 3 个分发策略:
 ```yaml
 # emptymatch.yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -590,12 +598,13 @@ spec:
       clusterNames:
         - member3
 ```
-The `nginx` deployment in `default` namespace will be propagated to cluster `member3`.
+此时，`default` 命名空间下的 `nginx` Deployment 会匹配隐式优先级最高的策略，最终分发到 `member3` 集群。
 
-### Choose from same-priority PropagationPolicies
-If multiple PropagationPolicies with the same explicit priority match the workload, the one with the highest implicit priority will be selected.
+### 从同优先级的分发策略中选择
 
-Assume there are multiple policies:
+如果多个具有相同显式优先级的分发策略匹配工作负载，则会选择隐式优先级最高的那个。
+
+假设有以下 2 个分发策略:
 ```yaml
 # explicit-labelselectormatch.yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -631,11 +640,11 @@ spec:
       clusterNames:
         - member3
 ```
-The `nginx` deployment in `default` namespace will be propagated to cluster `member3`.
+此时，两个策略显式优先级相同，但 `explicit-namematch.yaml` 的隐式优先级更高，因此 `default` 命名空间下的 `nginx` Deployment 会分发到 `member3` 集群。
 
-If both explicit and implicit priorities are the same, Karmada applies the PropagationPolicy in an ascending alphabetical order, for example, choosing xxx-a-xxx instead of xxx-b-xxx.
+若多个分发策略的显式优先级和隐式优先级均相同，则 Karmada 会按策略名称的字母升序选择（例如，优先选择名称为 `xxx-a-xxx` 的策略，而非 `xxx-b-xxx`）。
 
-Assume there are multiple policies:
+假设有以下 2 个分发策略：
 ```yaml
 # higher-alphabetical.yaml
 apiVersion: policy.karmada.io/v1alpha1
@@ -669,7 +678,7 @@ spec:
       clusterNames:
         - member2
 ```
-The `nginx` deployment in `default` namespace will be propagated to cluster `member2`.
+此时，两个策略优先级完全相同，但 `propagation-a-lower-alphabetical` 的名称字母序更靠前，因此 `default` 命名空间下的 `nginx` Deployment 会分发到 `member2` 集群。
 
 
 ## 暂停与恢复资源分发
@@ -743,4 +752,4 @@ spec:
   #...
 ```
 
-Karmada 控制平面中的 `nginx` Deployment 状态将被同步到所有成员集群，任何后续的更新也将被同步。
+Karmada 控制平面中的 nginx Deployment 状态将被同步到所有成员集群，任何后续的更新也将被同步。


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR completes the Chinese translation of the document `website\i18n\zh\docusaurus-plugin-content-docs\current\userguide\scheduling\resource-propagating.md`. The translation content is consistent with the English original version, covering all details of the "Resource Propagating" (资源传播) related user guide. This translation helps Chinese-speaking users better understand the scheduling-related resource propagation mechanism in the project, improving the accessibility of the document for the Chinese user group.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
1. Please check whether the translation accuracy is consistent with the English original (especially professional terms such as "Resource Propagating").
2. Please confirm that the document format (such as internal links, code blocks, list structures) remains intact after translation and can be normally rendered in the Chinese version of the website.
3. If there is a unified Chinese translation standard for project-specific terms, please help verify whether this PR complies with the standard.

