### PR TITLE
Bump Node.js version to 22

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
   publish = "build"
 
 [build.environment]
-    NODE_VERSION = "18"
+    NODE_VERSION = "22"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This pull request focuses on upgrading the Node.js runtime environment for the project's Netlify deployment. By bumping the version to 22. 

As it is required to have Node.js version greater than 20 before upgrading the Docusaurus framework to V3.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Echo the log from https://app.netlify.com/projects/karmada/deploys/68fa5b99c1327b0009acb8e0 in PR #903.

```bash
12:46:02 AM: [ERROR] Minimum Node.js version not met :(
12:46:02 AM: [INFO] You are using Node.js v18.20.8, Requirement: Node.js >=20.0.
```

