### PR TITLE
replace siteConfig.onBrokenMarkdownLinks by siteConfig.markdown.hook.onBrokenMarkdownLinks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,6 @@ module.exports = {
   url: "https://karmada.io",
   baseUrl: "/",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
   organizationName: "karmada-io",
   projectName: "website",
   i18n: {
@@ -240,4 +239,9 @@ module.exports = {
       },
     ],
   ],
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "throw",
+    }
+  },
 };


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
https://app.netlify.com/projects/karmada/deploys/69158ae7cb564600087b487e#L107-L108
```md
3:39:16 PM: [WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
3:39:16 PM: Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


