### PR TITLE
Update karmada-operator requirement for PDB resources

### DIFF
--- a/docs/administrator/security/component-permission.md
+++ b/docs/administrator/security/component-permission.md
@@ -28,6 +28,7 @@ The Karmada operator is a method for installing, upgrading, and deleting Karmada
 | services        | ""                  | *              | *         | get, create, update, delete | To manage services to expose applications within the cluster |
 | statefulsets    | ""                  | *              | *         | get, create, update, delete | To manage StatefulSets, e.g., etcd                           |
 | deployments     | apps                | *              | *         | get, create, update, delete | To manage Deployments, e.g., karmada-apiserver               |
+| poddisruptionbudgets | policy              | *              | *         | get, create, update, delete | To manage PodDisruptionBudget for components             |
 
 | Non-Resource URLs | Verbs | Description |
 |-------------|-------|-------------|

--- a/i18n/zh/docusaurus-plugin-content-docs/current/administrator/security/component-permission.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/administrator/security/component-permission.md
@@ -25,9 +25,10 @@ Karmada-operator 是一种用于安装、升级和删除 Karmada 实例的组件
 | pods            | ""                  | *              | *         | list                        | 用于 pod 的健康检查                                          |
 | namespaces      | ""                  | *              | *         | get                         | 用于获取命名空间信息，并将资源部署到特定命名空间中           |
 | secrets         | ""                  | *              | *         | get, create, update, delete | 用于管理 Secret（可能包含敏感数据，如认证信息）              |
-| services        | ""                  | *              | *         | get, create, update, delete | 用于管理Service，为集群内应用提供服务发现                    |
+| services        | ""                  | *              | *         | get, create, update, delete | 用于管理 Service，为集群内应用提供服务发现                    |
 | statefulsets    | ""                  | *              | *         | get, create, update, delete | 用于管理 StatefulSet（如 etcd）                              |
-| deployments     | apps                | *              | *         | get, create, update, delete | 用于管理Deployment（如 karmada-apiserver)                    |
+| deployments     | apps                | *              | *         | get, create, update, delete | 用于管理 Deployment（如 karmada-apiserver)                    |
+| poddisruptionbudgets | policy              | *              | *         | get, create, update, delete | 用于管理组件的 PodDisruptionBudget 配置             |
 
 | Non-Resource URLs | Verbs | Description |
 |-------------|-------|-------------|


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/kind feature

**What this PR does / why we need it**:
This pull request updates the Karmada operator's security documentation to accurately reflect its requirement for managing PodDisruptionBudgets (PDBs). By adding PDB permissions to the operator's role.

**Which issue(s) this PR fixes**:
Part of https://github.com/karmada-io/karmada/issues/6282

**Special notes for your reviewer**:


