### PR TITLE
fix wrong prometheus-config in working-with-prometheus-in-control-plane

### DIFF
--- a/docs/administrator/monitoring/working-with-prometheus-in-control-plane.md
+++ b/docs/administrator/monitoring/working-with-prometheus-in-control-plane.md
@@ -114,33 +114,41 @@ hack/local-up-karmada.sh
        - job_name: 'karmada-scheduler'
          kubernetes_sd_configs:
          - role: pod
+           namespaces:
+             names:
+             - karmada-system
          scheme: http
-         tls_config:
-           insecure_skip_verify: true
          relabel_configs:
-         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+         - source_labels: [__meta_kubernetes_pod_label_app]
            action: keep
-           regex: karmada-system;karmada-scheduler
-         - target_label: __address__
-           source_labels: [__address__]
-           regex: '(.*)'
-           replacement: '${1}:10351'
-           action: replace 
+           regex: karmada-scheduler
+         - source_labels: [__meta_kubernetes_pod_ip]
+           target_label: __address__
+           replacement: '${1}:8080'
+           action: replace
+         - source_labels: [__meta_kubernetes_pod_name]
+           target_label: pod
+         - source_labels: [__meta_kubernetes_namespace]
+           target_label: namespace 
        - job_name: 'karmada-controller-manager'
          kubernetes_sd_configs:
          - role: pod
+           namespaces:
+             names:
+             - karmada-system
          scheme: http
-         tls_config:
-           insecure_skip_verify: true
          relabel_configs:
-         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+         - source_labels: [__meta_kubernetes_pod_label_app]
            action: keep
-           regex: karmada-system;karmada-controller-manager
-         - target_label: __address__
-           source_labels: [__address__]
-           regex: '(.*)'
+           regex: karmada-controller-manager
+         - source_labels: [__meta_kubernetes_pod_ip]
+           target_label: __address__
            replacement: '${1}:8080'
-           action: replace                
+           action: replace
+         - source_labels: [__meta_kubernetes_pod_name]
+           target_label: pod
+         - source_labels: [__meta_kubernetes_namespace]
+           target_label: namespace                
        - job_name: 'kubernetes-apiserver'
          kubernetes_sd_configs:
          - role: endpoints

--- a/i18n/zh/docusaurus-plugin-content-docs/current/administrator/monitoring/working-with-prometheus-in-control-plane.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/administrator/monitoring/working-with-prometheus-in-control-plane.md
@@ -114,33 +114,41 @@ hack/local-up-karmada.sh
        - job_name: 'karmada-scheduler'
          kubernetes_sd_configs:
          - role: pod
+           namespaces:
+             names:
+             - karmada-system
          scheme: http
-         tls_config:
-           insecure_skip_verify: true
          relabel_configs:
-         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+         - source_labels: [__meta_kubernetes_pod_label_app]
            action: keep
-           regex: karmada-system;karmada-scheduler
-         - target_label: __address__
-           source_labels: [__address__]
-           regex: '(.*)'
-           replacement: '${1}:10351'
-           action: replace 
+           regex: karmada-scheduler
+         - source_labels: [__meta_kubernetes_pod_ip]
+           target_label: __address__
+           replacement: '${1}:8080'
+           action: replace
+         - source_labels: [__meta_kubernetes_pod_name]
+           target_label: pod
+         - source_labels: [__meta_kubernetes_namespace]
+           target_label: namespace 
        - job_name: 'karmada-controller-manager'
          kubernetes_sd_configs:
          - role: pod
+           namespaces:
+             names:
+             - karmada-system
          scheme: http
-         tls_config:
-           insecure_skip_verify: true
          relabel_configs:
-         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+         - source_labels: [__meta_kubernetes_pod_label_app]
            action: keep
-           regex: karmada-system;karmada-controller-manager
-         - target_label: __address__
-           source_labels: [__address__]
-           regex: '(.*)'
+           regex: karmada-controller-manager
+         - source_labels: [__meta_kubernetes_pod_ip]
+           target_label: __address__
            replacement: '${1}:8080'
            action: replace
+         - source_labels: [__meta_kubernetes_pod_name]
+           target_label: pod
+         - source_labels: [__meta_kubernetes_namespace]
+           target_label: namespace
        - job_name: 'kubernetes-apiserver'
          kubernetes_sd_configs:
          - role: endpoints

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.16/administrator/monitoring/working-with-prometheus-in-control-plane.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.16/administrator/monitoring/working-with-prometheus-in-control-plane.md
@@ -114,33 +114,41 @@ hack/local-up-karmada.sh
        - job_name: 'karmada-scheduler'
          kubernetes_sd_configs:
          - role: pod
+           namespaces:
+             names:
+             - karmada-system
          scheme: http
-         tls_config:
-           insecure_skip_verify: true
          relabel_configs:
-         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+         - source_labels: [__meta_kubernetes_pod_label_app]
            action: keep
-           regex: karmada-system;karmada-scheduler
-         - target_label: __address__
-           source_labels: [__address__]
-           regex: '(.*)'
-           replacement: '${1}:10351'
-           action: replace 
+           regex: karmada-scheduler
+         - source_labels: [__meta_kubernetes_pod_ip]
+           target_label: __address__
+           replacement: '${1}:8080'
+           action: replace
+         - source_labels: [__meta_kubernetes_pod_name]
+           target_label: pod
+         - source_labels: [__meta_kubernetes_namespace]
+           target_label: namespace 
        - job_name: 'karmada-controller-manager'
          kubernetes_sd_configs:
          - role: pod
+           namespaces:
+             names:
+             - karmada-system
          scheme: http
-         tls_config:
-           insecure_skip_verify: true
          relabel_configs:
-         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+         - source_labels: [__meta_kubernetes_pod_label_app]
            action: keep
-           regex: karmada-system;karmada-controller-manager
-         - target_label: __address__
-           source_labels: [__address__]
-           regex: '(.*)'
+           regex: karmada-controller-manager
+         - source_labels: [__meta_kubernetes_pod_ip]
+           target_label: __address__
            replacement: '${1}:8080'
            action: replace
+         - source_labels: [__meta_kubernetes_pod_name]
+           target_label: pod
+         - source_labels: [__meta_kubernetes_namespace]
+           target_label: namespace
        - job_name: 'kubernetes-apiserver'
          kubernetes_sd_configs:
          - role: endpoints

--- a/versioned_docs/version-v1.16/administrator/monitoring/working-with-prometheus-in-control-plane.md
+++ b/versioned_docs/version-v1.16/administrator/monitoring/working-with-prometheus-in-control-plane.md
@@ -114,33 +114,41 @@ hack/local-up-karmada.sh
        - job_name: 'karmada-scheduler'
          kubernetes_sd_configs:
          - role: pod
+           namespaces:
+             names:
+             - karmada-system
          scheme: http
-         tls_config:
-           insecure_skip_verify: true
          relabel_configs:
-         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+         - source_labels: [__meta_kubernetes_pod_label_app]
            action: keep
-           regex: karmada-system;karmada-scheduler
-         - target_label: __address__
-           source_labels: [__address__]
-           regex: '(.*)'
-           replacement: '${1}:10351'
-           action: replace 
+           regex: karmada-scheduler
+         - source_labels: [__meta_kubernetes_pod_ip]
+           target_label: __address__
+           replacement: '${1}:8080'
+           action: replace
+         - source_labels: [__meta_kubernetes_pod_name]
+           target_label: pod
+         - source_labels: [__meta_kubernetes_namespace]
+           target_label: namespace 
        - job_name: 'karmada-controller-manager'
          kubernetes_sd_configs:
          - role: pod
+           namespaces:
+             names:
+             - karmada-system
          scheme: http
-         tls_config:
-           insecure_skip_verify: true
          relabel_configs:
-         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+         - source_labels: [__meta_kubernetes_pod_label_app]
            action: keep
-           regex: karmada-system;karmada-controller-manager
-         - target_label: __address__
-           source_labels: [__address__]
-           regex: '(.*)'
+           regex: karmada-controller-manager
+         - source_labels: [__meta_kubernetes_pod_ip]
+           target_label: __address__
            replacement: '${1}:8080'
-           action: replace                
+           action: replace
+         - source_labels: [__meta_kubernetes_pod_name]
+           target_label: pod
+         - source_labels: [__meta_kubernetes_namespace]
+           target_label: namespace                
        - job_name: 'kubernetes-apiserver'
          kubernetes_sd_configs:
          - role: endpoints


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

When I deploy Prometheus deployment in karmada control plane refer to the doc: https://karmada.io/docs/administrator/monitoring/working-with-prometheus-in-control-plane, I find that I can't get the metrics with the comment `karmada-controller-manager` and `karmada-scheduler`.

I checkout the promethus job health:

```
# curl -s "http://localhost:xxxx/api/v1/targets" | jq '.data.activeTargets[] | select(.labels.job=="karmada-controller-manager") | {labels: .labels, health: .health, lastError: .lastError}'
{
  "labels": {
    "instance": "10.244.0.12:8080:8080",
    "job": "karmada-controller-manager"
  },
  "health": "down",
  "lastError": "Get \"http://10.244.0.12:8080:8080/metrics\": dial tcp: lookup 10.244.0.12:8080: no such host: address 10.244.0.12:8080:8080: too many colons in address"
}
{
  "labels": {
    "instance": "10.244.0.13:8080:8080",
    "job": "karmada-controller-manager"
  },
  "health": "down",
  "lastError": "Get \"http://10.244.0.13:8080:8080/metrics\": dial tcp: lookup 10.244.0.13:8080: no such host: address 10.244.0.13:8080:8080: too many colons in address"
}

# curl -s "http://localhost:xxxx/api/v1/targets" | jq '.data.activeTargets[] | select(.labels.job=="karmada-scheduler") | {labels: .labels, health: .health, lastError: .lastError}'
{
  "labels": {
    "instance": "10.244.0.15:8080:10351",
    "job": "karmada-scheduler"
  },
  "health": "down",
  "lastError": "Get \"http://10.244.0.15:8080:10351/metrics\": dial tcp: lookup 10.244.0.15:8080: no such host: address 10.244.0.15:8080:10351: too many colons in address"
}
{
  "labels": {
    "instance": "10.244.0.14:8080:10351",
    "job": "karmada-scheduler"
  },
  "health": "down",
  "lastError": "Get \"http://10.244.0.14:8080:10351/metrics\": dial tcp: lookup 10.244.0.14:8080: no such host: address 10.244.0.14:8080:10351: too many colons in address"
}
```

It can see that their health was down, so I fiexed it.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


