### PR TITLE
docs: fix grammar in components etcd section.

### DIFF
--- a/docs/core-concepts/components.md
+++ b/docs/core-concepts/components.md
@@ -74,7 +74,7 @@ validating webhooks are invoked and can reject requests to enforce custom polici
 
 ### etcd
 
-Consistent and highly-available key value store used as Karmada' backing store for all Karmada/Kubernetes API objects.
+Consistent and highly-available key value store used as Karmada's backing store for all Karmada/Kubernetes API objects.
 
 If your Karmada uses etcd as its backing store, make sure you have a back up plan for the data.
 

--- a/versioned_docs/version-v1.11/core-concepts/components.md
+++ b/versioned_docs/version-v1.11/core-concepts/components.md
@@ -74,7 +74,7 @@ validating webhooks are invoked and can reject requests to enforce custom polici
 
 ### etcd
 
-Consistent and highly-available key value store used as Karmada' backing store for all Karmada/Kubernetes API objects.
+Consistent and highly-available key value store used as Karmada's backing store for all Karmada/Kubernetes API objects.
 
 If your Karmada uses etcd as its backing store, make sure you have a back up plan for the data.
 

--- a/versioned_docs/version-v1.12/core-concepts/components.md
+++ b/versioned_docs/version-v1.12/core-concepts/components.md
@@ -74,7 +74,7 @@ validating webhooks are invoked and can reject requests to enforce custom polici
 
 ### etcd
 
-Consistent and highly-available key value store used as Karmada' backing store for all Karmada/Kubernetes API objects.
+Consistent and highly-available key value store used as Karmada's backing store for all Karmada/Kubernetes API objects.
 
 If your Karmada uses etcd as its backing store, make sure you have a back up plan for the data.
 

--- a/versioned_docs/version-v1.13/core-concepts/components.md
+++ b/versioned_docs/version-v1.13/core-concepts/components.md
@@ -74,7 +74,7 @@ validating webhooks are invoked and can reject requests to enforce custom polici
 
 ### etcd
 
-Consistent and highly-available key value store used as Karmada' backing store for all Karmada/Kubernetes API objects.
+Consistent and highly-available key value store used as Karmada's backing store for all Karmada/Kubernetes API objects.
 
 If your Karmada uses etcd as its backing store, make sure you have a back up plan for the data.
 

--- a/versioned_docs/version-v1.14/core-concepts/components.md
+++ b/versioned_docs/version-v1.14/core-concepts/components.md
@@ -74,7 +74,7 @@ validating webhooks are invoked and can reject requests to enforce custom polici
 
 ### etcd
 
-Consistent and highly-available key value store used as Karmada' backing store for all Karmada/Kubernetes API objects.
+Consistent and highly-available key value store used as Karmada's backing store for all Karmada/Kubernetes API objects.
 
 If your Karmada uses etcd as its backing store, make sure you have a back up plan for the data.
 

--- a/versioned_docs/version-v1.15/core-concepts/components.md
+++ b/versioned_docs/version-v1.15/core-concepts/components.md
@@ -74,7 +74,7 @@ validating webhooks are invoked and can reject requests to enforce custom polici
 
 ### etcd
 
-Consistent and highly-available key value store used as Karmada' backing store for all Karmada/Kubernetes API objects.
+Consistent and highly-available key value store used as Karmada's backing store for all Karmada/Kubernetes API objects.
 
 If your Karmada uses etcd as its backing store, make sure you have a back up plan for the data.
 

--- a/versioned_docs/version-v1.16/core-concepts/components.md
+++ b/versioned_docs/version-v1.16/core-concepts/components.md
@@ -74,7 +74,7 @@ validating webhooks are invoked and can reject requests to enforce custom polici
 
 ### etcd
 
-Consistent and highly-available key value store used as Karmada' backing store for all Karmada/Kubernetes API objects.
+Consistent and highly-available key value store used as Karmada's backing store for all Karmada/Kubernetes API objects.
 
 If your Karmada uses etcd as its backing store, make sure you have a back up plan for the data.
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:
Fixes a small possessive typo in the Components documentation (etcd section) to improve clarity and professionalism of the docs.

**Which issue(s) this PR fixes**:
Fixes #970 

**Special notes for your reviewer**:
The same typo existed in multiple versioned documentation, so it has been fixed consistently in all affected versions.
