### PR TITLE
docs: improve wording in Open and Neutral section

### DIFF
--- a/docs/core-concepts/introduction.md
+++ b/docs/core-concepts/introduction.md
@@ -36,7 +36,7 @@ Karmada is an incubation project of the [Cloud Native Computing Foundation](http
     - Multi-Dimension HA: Region/AZ/Cluster/Provider
 
 - __Open and Neutral__
-    - Jointly initiated by Internet, finance, manufacturing, teleco, cloud providers, etc.
+    - Jointly initiated by Internet, finance, manufacturing, telecommunications, cloud providers, etc.
     - Target for open governance with CNCF
 
 

--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -230,7 +230,7 @@
   "Open and Neutral": {
     "message": "开放和中立"
   },
-  "Jointly initiated by Internet, finance, manufacturing, teleco, cloud providers, etc. Target for open governance with CNCF": {
+  "Jointly initiated by Internet, finance, manufacturing, telecommunications, cloud providers, etc. Target for open governance with CNCF": {
     "message": "由互联网、金融、制造业、电信、云提供商等联合发起。目标是与 CNCF 一起进行开放治理。"
   },
   "Avoid Vendor Lock-in": {

--- a/src/data/features.js
+++ b/src/data/features.js
@@ -17,7 +17,7 @@ const features = [
         // imgUrl: 'img/logo.svg',
         description: (
             <Translate>
-                Jointly initiated by Internet, finance, manufacturing, teleco, cloud providers, etc. Target for open
+                Jointly initiated by Internet, finance, manufacturing, telecommunications, cloud providers, etc. Target for open
                 governance with CNCF
             </Translate>
         ),

--- a/versioned_docs/version-v1.11/core-concepts/introduction.md
+++ b/versioned_docs/version-v1.11/core-concepts/introduction.md
@@ -36,7 +36,7 @@ Karmada is an incubation project of the [Cloud Native Computing Foundation](http
     - Multi-Dimension HA: Region/AZ/Cluster/Provider
 
 - __Open and Neutral__
-    - Jointly initiated by Internet, finance, manufacturing, teleco, cloud providers, etc.
+    - Jointly initiated by Internet, finance, manufacturing, telecommunications, cloud providers, etc.
     - Target for open governance with CNCF
 
 

--- a/versioned_docs/version-v1.12/core-concepts/introduction.md
+++ b/versioned_docs/version-v1.12/core-concepts/introduction.md
@@ -36,7 +36,7 @@ Karmada is an incubation project of the [Cloud Native Computing Foundation](http
     - Multi-Dimension HA: Region/AZ/Cluster/Provider
 
 - __Open and Neutral__
-    - Jointly initiated by Internet, finance, manufacturing, teleco, cloud providers, etc.
+    - Jointly initiated by Internet, finance, manufacturing, telecommunications, cloud providers, etc.
     - Target for open governance with CNCF
 
 

--- a/versioned_docs/version-v1.13/core-concepts/introduction.md
+++ b/versioned_docs/version-v1.13/core-concepts/introduction.md
@@ -36,7 +36,7 @@ Karmada is an incubation project of the [Cloud Native Computing Foundation](http
     - Multi-Dimension HA: Region/AZ/Cluster/Provider
 
 - __Open and Neutral__
-    - Jointly initiated by Internet, finance, manufacturing, teleco, cloud providers, etc.
+    - Jointly initiated by Internet, finance, manufacturing, telecommunications, cloud providers, etc.
     - Target for open governance with CNCF
 
 

--- a/versioned_docs/version-v1.14/core-concepts/introduction.md
+++ b/versioned_docs/version-v1.14/core-concepts/introduction.md
@@ -36,7 +36,7 @@ Karmada is an incubation project of the [Cloud Native Computing Foundation](http
     - Multi-Dimension HA: Region/AZ/Cluster/Provider
 
 - __Open and Neutral__
-    - Jointly initiated by Internet, finance, manufacturing, teleco, cloud providers, etc.
+    - Jointly initiated by Internet, finance, manufacturing, telecommunications, cloud providers, etc.
     - Target for open governance with CNCF
 
 

--- a/versioned_docs/version-v1.15/core-concepts/introduction.md
+++ b/versioned_docs/version-v1.15/core-concepts/introduction.md
@@ -36,7 +36,7 @@ Karmada is an incubation project of the [Cloud Native Computing Foundation](http
     - Multi-Dimension HA: Region/AZ/Cluster/Provider
 
 - __Open and Neutral__
-    - Jointly initiated by Internet, finance, manufacturing, teleco, cloud providers, etc.
+    - Jointly initiated by Internet, finance, manufacturing, telecommunications, cloud providers, etc.
     - Target for open governance with CNCF
 
 

--- a/versioned_docs/version-v1.16/core-concepts/introduction.md
+++ b/versioned_docs/version-v1.16/core-concepts/introduction.md
@@ -36,7 +36,7 @@ Karmada is an incubation project of the [Cloud Native Computing Foundation](http
     - Multi-Dimension HA: Region/AZ/Cluster/Provider
 
 - __Open and Neutral__
-    - Jointly initiated by Internet, finance, manufacturing, teleco, cloud providers, etc.
+    - Jointly initiated by Internet, finance, manufacturing, telecommunications, cloud providers, etc.
     - Target for open governance with CNCF
 
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Improves clarity and fixes a typo in the "Open and Neutral" section by correcting wording of "teleco" to "telecommunications" and sentence structure.

**Which issue(s) this PR fixes**:
Fixes #972 

**Special notes for your reviewer**:

This change focuses on improving readability while keeping the original intentention.

<img width="729" height="78" alt="Screenshot 2026-02-07 at 11 33 27 PM" src="https://github.com/user-attachments/assets/7d7c2fc5-ef0f-4cab-a1c4-6b25b61b3009" />
