### PR TITLE
Add website: import useBaseUrl in featuresList component

### DIFF
--- a/src/components/featuresList.js
+++ b/src/components/featuresList.js
@@ -1,5 +1,6 @@
 import React from "react";
 import styles from "../pages/styles.module.css";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 function Feature({imgUrl, title, description}) {
     return (


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Adds the missing `useBaseUrl` import in the features list component to prevent potential runtime or build errors.

**Which issue(s) this PR fixes**:
Fixes #978

**Special notes for your reviewer**:
This change is minimal and limited to adding the missing import.

<img width="964" height="473" alt="Screenshot 2026-02-08 at 8 53 57 AM" src="https://github.com/user-attachments/assets/2bc917ef-5e4d-4e4f-a897-5dbdbc697ac4" />
