### PR TITLE
docs: fix typos across documentation

### DIFF
--- a/docs/administrator/configuration/priority-class-configuration.md
+++ b/docs/administrator/configuration/priority-class-configuration.md
@@ -94,7 +94,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         The priority class name for the component karmada-scheduler-estimator.
     --metrics-adapter-priority-class='system-node-critical':
-        The priority class name for the component karmada-metrics-adaptor.
+        The priority class name for the component karmada-metrics-adapter.
     --search-priority-class='system-node-critical':
         The priority class name for the component karmada-search.
 ```

--- a/docs/developers/document-releasing.md
+++ b/docs/developers/document-releasing.md
@@ -10,7 +10,7 @@ Sometimes contributors do not update the content of the documentation in all lan
 This will be tracked by an issue. The issue should follow the format:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/administrator/compatibility/compatibility.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/administrator/compatibility/compatibility.md
@@ -11,7 +11,7 @@ title: Kubernetes 兼容性
 
 ## Karmada 控制平面 API 支持
 
-Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如 Karmada APIServer 使用 kube-apiserver@v1.32，
+Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如果 Karmada APIServer 使用 kube-apiserver@v1.32，
 则继承支持 Kubernetes v1.32 中所有 API（如 Deployment、Service、Ingress）及 API 版本（如 apps/v1、networking.k8s.io/v1）。
 
 除原生 Kubernetes API 外，Karmada 可通过以下与 Kubernetes 相同的扩展机制增强能力：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/administrator/configuration/priority-class-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/administrator/configuration/priority-class-configuration.md
@@ -95,7 +95,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         karmada-scheduler-estimator 组件的优先级类名称。
     --metrics-adapter-priority-class='system-node-critical':
-        karmada-metrics-adaptor 组件的优先级类名称。
+        karmada-metrics-adapter 组件的优先级类名称。
     --search-priority-class='system-node-critical':
         karmada-search 组件的优先级类名称。
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/developers/document-releasing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/developers/document-releasing.md
@@ -9,7 +9,7 @@ title: 文档发布
 有时贡献者不会更新所有语言文档的内容。在发布之前，请确保多语种文档同步。这将通过一个 issue 来跟踪。issue 应遵循以下格式:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.13/administrator/configuration/priority-class-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.13/administrator/configuration/priority-class-configuration.md
@@ -95,7 +95,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         karmada-scheduler-estimator 组件的优先级类名称。
     --metrics-adapter-priority-class='system-node-critical':
-        karmada-metrics-adaptor 组件的优先级类名称。
+        karmada-metrics-adapter 组件的优先级类名称。
     --search-priority-class='system-node-critical':
         karmada-search 组件的优先级类名称。
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.13/developers/document-releasing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.13/developers/document-releasing.md
@@ -9,7 +9,7 @@ title: 文档发布
 有时贡献者不会更新所有语言文档的内容。在发布之前，请确保多语种文档同步。这将通过一个 issue 来跟踪。issue 应遵循以下格式:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.13/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.13/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
@@ -63,7 +63,7 @@ karmadactl addons enable
       --kubeconfig string                          Path to the host cluster kubeconfig file.
       --member-context string                      Member cluster's context which to deploy scheduler estimator
       --member-kubeconfig string                   Member cluster's kubeconfig which to deploy scheduler estimator
-      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adaptor. (default "system-node-critical")
+      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adapter. (default "system-node-critical")
   -n, --namespace string                           namespace where Karmada components are installed. (default "karmada-system")
       --pod-timeout int                            Wait pod ready timeout. (default 120)
       --private-image-registry string              Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.14/administrator/compatibility/compatibility.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.14/administrator/compatibility/compatibility.md
@@ -11,7 +11,7 @@ title: Kubernetes 兼容性
 
 ## Karmada 控制平面 API 支持
 
-Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如 Karmada APIServer 使用 kube-apiserver@v1.32，
+Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如果 Karmada APIServer 使用 kube-apiserver@v1.32，
 则继承支持 Kubernetes v1.32 中所有 API（如 Deployment、Service、Ingress）及 API 版本（如 apps/v1、networking.k8s.io/v1）。
 
 除原生 Kubernetes API 外，Karmada 可通过以下与 Kubernetes 相同的扩展机制增强能力：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.14/administrator/configuration/priority-class-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.14/administrator/configuration/priority-class-configuration.md
@@ -95,7 +95,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         karmada-scheduler-estimator 组件的优先级类名称。
     --metrics-adapter-priority-class='system-node-critical':
-        karmada-metrics-adaptor 组件的优先级类名称。
+        karmada-metrics-adapter 组件的优先级类名称。
     --search-priority-class='system-node-critical':
         karmada-search 组件的优先级类名称。
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.14/developers/document-releasing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.14/developers/document-releasing.md
@@ -9,7 +9,7 @@ title: 文档发布
 有时贡献者不会更新所有语言文档的内容。在发布之前，请确保多语种文档同步。这将通过一个 issue 来跟踪。issue 应遵循以下格式:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.14/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.14/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
@@ -63,7 +63,7 @@ karmadactl addons enable
       --kubeconfig string                          Path to the host cluster kubeconfig file.
       --member-context string                      Member cluster's context which to deploy scheduler estimator
       --member-kubeconfig string                   Member cluster's kubeconfig which to deploy scheduler estimator
-      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adaptor. (default "system-node-critical")
+      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adapter. (default "system-node-critical")
   -n, --namespace string                           namespace where Karmada components are installed. (default "karmada-system")
       --pod-timeout int                            Wait pod ready timeout. (default 120)
       --private-image-registry string              Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.15/administrator/compatibility/compatibility.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.15/administrator/compatibility/compatibility.md
@@ -11,7 +11,7 @@ title: Kubernetes 兼容性
 
 ## Karmada 控制平面 API 支持
 
-Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如 Karmada APIServer 使用 kube-apiserver@v1.32，
+Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如果 Karmada APIServer 使用 kube-apiserver@v1.32，
 则继承支持 Kubernetes v1.32 中所有 API（如 Deployment、Service、Ingress）及 API 版本（如 apps/v1、networking.k8s.io/v1）。
 
 除原生 Kubernetes API 外，Karmada 可通过以下与 Kubernetes 相同的扩展机制增强能力：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.15/administrator/configuration/priority-class-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.15/administrator/configuration/priority-class-configuration.md
@@ -95,7 +95,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         karmada-scheduler-estimator 组件的优先级类名称。
     --metrics-adapter-priority-class='system-node-critical':
-        karmada-metrics-adaptor 组件的优先级类名称。
+        karmada-metrics-adapter 组件的优先级类名称。
     --search-priority-class='system-node-critical':
         karmada-search 组件的优先级类名称。
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.15/developers/document-releasing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.15/developers/document-releasing.md
@@ -9,7 +9,7 @@ title: 文档发布
 有时贡献者不会更新所有语言文档的内容。在发布之前，请确保多语种文档同步。这将通过一个 issue 来跟踪。issue 应遵循以下格式:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.15/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.15/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
@@ -63,7 +63,7 @@ karmadactl addons enable
       --kubeconfig string                          Path to the host cluster kubeconfig file.
       --member-context string                      Member cluster's context which to deploy scheduler estimator
       --member-kubeconfig string                   Member cluster's kubeconfig which to deploy scheduler estimator
-      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adaptor. (default "system-node-critical")
+      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adapter. (default "system-node-critical")
   -n, --namespace string                           namespace where Karmada components are installed. (default "karmada-system")
       --pod-timeout int                            Wait pod ready timeout. (default 120)
       --private-image-registry string              Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.16/administrator/compatibility/compatibility.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.16/administrator/compatibility/compatibility.md
@@ -11,7 +11,7 @@ title: Kubernetes 兼容性
 
 ## Karmada 控制平面 API 支持
 
-Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如 Karmada APIServer 使用 kube-apiserver@v1.32，
+Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如果 Karmada APIServer 使用 kube-apiserver@v1.32，
 则继承支持 Kubernetes v1.32 中所有 API（如 Deployment、Service、Ingress）及 API 版本（如 apps/v1、networking.k8s.io/v1）。
 
 除原生 Kubernetes API 外，Karmada 可通过以下与 Kubernetes 相同的扩展机制增强能力：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.16/administrator/configuration/priority-class-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.16/administrator/configuration/priority-class-configuration.md
@@ -95,7 +95,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         karmada-scheduler-estimator 组件的优先级类名称。
     --metrics-adapter-priority-class='system-node-critical':
-        karmada-metrics-adaptor 组件的优先级类名称。
+        karmada-metrics-adapter 组件的优先级类名称。
     --search-priority-class='system-node-critical':
         karmada-search 组件的优先级类名称。
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.16/developers/document-releasing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.16/developers/document-releasing.md
@@ -9,7 +9,7 @@ title: 文档发布
 有时贡献者不会更新所有语言文档的内容。在发布之前，请确保多语种文档同步。这将通过一个 issue 来跟踪。issue 应遵循以下格式:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.16/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.16/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
@@ -63,7 +63,7 @@ karmadactl addons enable
       --kubeconfig string                          Path to the host cluster kubeconfig file.
       --member-context string                      Member cluster's context which to deploy scheduler estimator
       --member-kubeconfig string                   Member cluster's kubeconfig which to deploy scheduler estimator
-      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adaptor. (default "system-node-critical")
+      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adapter. (default "system-node-critical")
   -n, --namespace string                           namespace where Karmada components are installed. (default "karmada-system")
       --pod-timeout int                            Wait pod ready timeout. (default 120)
       --private-image-registry string              Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.17/administrator/compatibility/compatibility.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.17/administrator/compatibility/compatibility.md
@@ -11,7 +11,7 @@ title: Kubernetes 兼容性
 
 ## Karmada 控制平面 API 支持
 
-Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如 Karmada APIServer 使用 kube-apiserver@v1.32，
+Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如果 Karmada APIServer 使用 kube-apiserver@v1.32，
 则继承支持 Kubernetes v1.32 中所有 API（如 Deployment、Service、Ingress）及 API 版本（如 apps/v1、networking.k8s.io/v1）。
 
 除原生 Kubernetes API 外，Karmada 可通过以下与 Kubernetes 相同的扩展机制增强能力：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.17/administrator/configuration/priority-class-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.17/administrator/configuration/priority-class-configuration.md
@@ -95,7 +95,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         karmada-scheduler-estimator 组件的优先级类名称。
     --metrics-adapter-priority-class='system-node-critical':
-        karmada-metrics-adaptor 组件的优先级类名称。
+        karmada-metrics-adapter 组件的优先级类名称。
     --search-priority-class='system-node-critical':
         karmada-search 组件的优先级类名称。
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.17/developers/document-releasing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.17/developers/document-releasing.md
@@ -9,7 +9,7 @@ title: 文档发布
 有时贡献者不会更新所有语言文档的内容。在发布之前，请确保多语种文档同步。这将通过一个 issue 来跟踪。issue 应遵循以下格式:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.17/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.17/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
@@ -63,7 +63,7 @@ karmadactl addons enable
       --kubeconfig string                          Path to the host cluster kubeconfig file.
       --member-context string                      Member cluster's context which to deploy scheduler estimator
       --member-kubeconfig string                   Member cluster's kubeconfig which to deploy scheduler estimator
-      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adaptor. (default "system-node-critical")
+      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adapter. (default "system-node-critical")
   -n, --namespace string                           namespace where Karmada components are installed. (default "karmada-system")
       --pod-timeout int                            Wait pod ready timeout. (default 120)
       --private-image-registry string              Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.18/administrator/compatibility/compatibility.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.18/administrator/compatibility/compatibility.md
@@ -11,7 +11,7 @@ title: Kubernetes 兼容性
 
 ## Karmada 控制平面 API 支持
 
-Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如 Karmada APIServer 使用 kube-apiserver@v1.32，
+Karmada 支持其使用的 kube-apiserver 版本中所有可用的 Kubernetes API。例如，如果 Karmada APIServer 使用 kube-apiserver@v1.32，
 则继承支持 Kubernetes v1.32 中所有 API（如 Deployment、Service、Ingress）及 API 版本（如 apps/v1、networking.k8s.io/v1）。
 
 除原生 Kubernetes API 外，Karmada 可通过以下与 Kubernetes 相同的扩展机制增强能力：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.18/administrator/configuration/priority-class-configuration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.18/administrator/configuration/priority-class-configuration.md
@@ -95,7 +95,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         karmada-scheduler-estimator 组件的优先级类名称。
     --metrics-adapter-priority-class='system-node-critical':
-        karmada-metrics-adaptor 组件的优先级类名称。
+        karmada-metrics-adapter 组件的优先级类名称。
     --search-priority-class='system-node-critical':
         karmada-search 组件的优先级类名称。
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.18/developers/document-releasing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.18/developers/document-releasing.md
@@ -9,7 +9,7 @@ title: 文档发布
 有时贡献者不会更新所有语言文档的内容。在发布之前，请确保多语种文档同步。这将通过一个 issue 来跟踪。issue 应遵循以下格式:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/versioned_docs/version-v1.13/administrator/configuration/priority-class-configuration.md
+++ b/versioned_docs/version-v1.13/administrator/configuration/priority-class-configuration.md
@@ -94,7 +94,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         The priority class name for the component karmada-scheduler-estimator.
     --metrics-adapter-priority-class='system-node-critical':
-        The priority class name for the component karmada-metrics-adaptor.
+        The priority class name for the component karmada-metrics-adapter.
     --search-priority-class='system-node-critical':
         The priority class name for the component karmada-search.
 ```

--- a/versioned_docs/version-v1.13/developers/document-releasing.md
+++ b/versioned_docs/version-v1.13/developers/document-releasing.md
@@ -10,7 +10,7 @@ Sometimes contributors do not update the content of the documentation in all lan
 This will be tracked by an issue. The issue should follow the format:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/versioned_docs/version-v1.13/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
+++ b/versioned_docs/version-v1.13/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
@@ -63,7 +63,7 @@ karmadactl addons enable
       --kubeconfig string                          Path to the host cluster kubeconfig file.
       --member-context string                      Member cluster's context which to deploy scheduler estimator
       --member-kubeconfig string                   Member cluster's kubeconfig which to deploy scheduler estimator
-      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adaptor. (default "system-node-critical")
+      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adapter. (default "system-node-critical")
   -n, --namespace string                           namespace where Karmada components are installed. (default "karmada-system")
       --pod-timeout int                            Wait pod ready timeout. (default 120)
       --private-image-registry string              Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.

--- a/versioned_docs/version-v1.14/administrator/configuration/priority-class-configuration.md
+++ b/versioned_docs/version-v1.14/administrator/configuration/priority-class-configuration.md
@@ -94,7 +94,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         The priority class name for the component karmada-scheduler-estimator.
     --metrics-adapter-priority-class='system-node-critical':
-        The priority class name for the component karmada-metrics-adaptor.
+        The priority class name for the component karmada-metrics-adapter.
     --search-priority-class='system-node-critical':
         The priority class name for the component karmada-search.
 ```

--- a/versioned_docs/version-v1.14/developers/document-releasing.md
+++ b/versioned_docs/version-v1.14/developers/document-releasing.md
@@ -10,7 +10,7 @@ Sometimes contributors do not update the content of the documentation in all lan
 This will be tracked by an issue. The issue should follow the format:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/versioned_docs/version-v1.14/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
+++ b/versioned_docs/version-v1.14/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
@@ -63,7 +63,7 @@ karmadactl addons enable
       --kubeconfig string                          Path to the host cluster kubeconfig file.
       --member-context string                      Member cluster's context which to deploy scheduler estimator
       --member-kubeconfig string                   Member cluster's kubeconfig which to deploy scheduler estimator
-      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adaptor. (default "system-node-critical")
+      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adapter. (default "system-node-critical")
   -n, --namespace string                           namespace where Karmada components are installed. (default "karmada-system")
       --pod-timeout int                            Wait pod ready timeout. (default 120)
       --private-image-registry string              Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.

--- a/versioned_docs/version-v1.15/administrator/configuration/priority-class-configuration.md
+++ b/versioned_docs/version-v1.15/administrator/configuration/priority-class-configuration.md
@@ -94,7 +94,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         The priority class name for the component karmada-scheduler-estimator.
     --metrics-adapter-priority-class='system-node-critical':
-        The priority class name for the component karmada-metrics-adaptor.
+        The priority class name for the component karmada-metrics-adapter.
     --search-priority-class='system-node-critical':
         The priority class name for the component karmada-search.
 ```

--- a/versioned_docs/version-v1.15/developers/document-releasing.md
+++ b/versioned_docs/version-v1.15/developers/document-releasing.md
@@ -10,7 +10,7 @@ Sometimes contributors do not update the content of the documentation in all lan
 This will be tracked by an issue. The issue should follow the format:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/versioned_docs/version-v1.15/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
+++ b/versioned_docs/version-v1.15/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
@@ -63,7 +63,7 @@ karmadactl addons enable
       --kubeconfig string                          Path to the host cluster kubeconfig file.
       --member-context string                      Member cluster's context which to deploy scheduler estimator
       --member-kubeconfig string                   Member cluster's kubeconfig which to deploy scheduler estimator
-      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adaptor. (default "system-node-critical")
+      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adapter. (default "system-node-critical")
   -n, --namespace string                           namespace where Karmada components are installed. (default "karmada-system")
       --pod-timeout int                            Wait pod ready timeout. (default 120)
       --private-image-registry string              Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.

--- a/versioned_docs/version-v1.16/administrator/configuration/priority-class-configuration.md
+++ b/versioned_docs/version-v1.16/administrator/configuration/priority-class-configuration.md
@@ -94,7 +94,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         The priority class name for the component karmada-scheduler-estimator.
     --metrics-adapter-priority-class='system-node-critical':
-        The priority class name for the component karmada-metrics-adaptor.
+        The priority class name for the component karmada-metrics-adapter.
     --search-priority-class='system-node-critical':
         The priority class name for the component karmada-search.
 ```

--- a/versioned_docs/version-v1.16/developers/document-releasing.md
+++ b/versioned_docs/version-v1.16/developers/document-releasing.md
@@ -10,7 +10,7 @@ Sometimes contributors do not update the content of the documentation in all lan
 This will be tracked by an issue. The issue should follow the format:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/versioned_docs/version-v1.16/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
+++ b/versioned_docs/version-v1.16/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
@@ -63,7 +63,7 @@ karmadactl addons enable
       --kubeconfig string                          Path to the host cluster kubeconfig file.
       --member-context string                      Member cluster's context which to deploy scheduler estimator
       --member-kubeconfig string                   Member cluster's kubeconfig which to deploy scheduler estimator
-      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adaptor. (default "system-node-critical")
+      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adapter. (default "system-node-critical")
   -n, --namespace string                           namespace where Karmada components are installed. (default "karmada-system")
       --pod-timeout int                            Wait pod ready timeout. (default 120)
       --private-image-registry string              Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.

--- a/versioned_docs/version-v1.17/administrator/configuration/priority-class-configuration.md
+++ b/versioned_docs/version-v1.17/administrator/configuration/priority-class-configuration.md
@@ -94,7 +94,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         The priority class name for the component karmada-scheduler-estimator.
     --metrics-adapter-priority-class='system-node-critical':
-        The priority class name for the component karmada-metrics-adaptor.
+        The priority class name for the component karmada-metrics-adapter.
     --search-priority-class='system-node-critical':
         The priority class name for the component karmada-search.
 ```

--- a/versioned_docs/version-v1.17/developers/document-releasing.md
+++ b/versioned_docs/version-v1.17/developers/document-releasing.md
@@ -10,7 +10,7 @@ Sometimes contributors do not update the content of the documentation in all lan
 This will be tracked by an issue. The issue should follow the format:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 

--- a/versioned_docs/version-v1.17/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
+++ b/versioned_docs/version-v1.17/reference/karmadactl/karmadactl-commands/karmadactl_addons_enable.md
@@ -63,7 +63,7 @@ karmadactl addons enable
       --kubeconfig string                          Path to the host cluster kubeconfig file.
       --member-context string                      Member cluster's context which to deploy scheduler estimator
       --member-kubeconfig string                   Member cluster's kubeconfig which to deploy scheduler estimator
-      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adaptor. (default "system-node-critical")
+      --metrics-adapter-priority-class string      The priority class name for the component karmada-metrics-adapter. (default "system-node-critical")
   -n, --namespace string                           namespace where Karmada components are installed. (default "karmada-system")
       --pod-timeout int                            Wait pod ready timeout. (default 120)
       --private-image-registry string              Private image registry where pull images from. If set, all required images will be downloaded from it, it would be useful in offline installation scenarios.

--- a/versioned_docs/version-v1.18/administrator/configuration/priority-class-configuration.md
+++ b/versioned_docs/version-v1.18/administrator/configuration/priority-class-configuration.md
@@ -94,7 +94,7 @@ $ karmadactl addons enable --help |grep priority
     --estimator-priority-class='system-node-critical':
         The priority class name for the component karmada-scheduler-estimator.
     --metrics-adapter-priority-class='system-node-critical':
-        The priority class name for the component karmada-metrics-adaptor.
+        The priority class name for the component karmada-metrics-adapter.
     --search-priority-class='system-node-critical':
         The priority class name for the component karmada-search.
 ```

--- a/versioned_docs/version-v1.18/developers/document-releasing.md
+++ b/versioned_docs/version-v1.18/developers/document-releasing.md
@@ -10,7 +10,7 @@ Sometimes contributors do not update the content of the documentation in all lan
 This will be tracked by an issue. The issue should follow the format:
 
 ```
-This issue is to track documents which needs to sync zh for release 1.x:
+This issue is to track documents which need to be synced with zh for release 1.x:
 * #268
 ```
 


### PR DESCRIPTION
Fixes #1021
Fix three typos identified by Gemini in #1019 across all versioned docs:

Fix Chinese typo: 如 Karmada APIServer → 如果 Karmada APIServer
Fix spelling: karmada-metrics-adaptor → karmada-metrics-adapter
Fix grammar: documents which needs to sync → documents which need to sync

Changes applied across all affected files in docs/, versioned_docs/, and i18n/zh/.