### PR TITLE
Update the FAQ makes the share kube-apiserver not recommanded

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -26,20 +26,26 @@ refer to [Kubernetes Controllers](../administrator/configuration/configure-contr
 
 ## Can I install Karmada in a Kubernetes cluster and reuse the kube-apiserver as Karmada apiserver?
 
-The quick answer is `yes`. In that case, you can save the effort to deploy
-[karmada-apiserver](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/karmada-apiserver.yaml) and just
-share the APIServer between Kubernetes and Karmada. In addition, the high availability capabilities in the origin clusters
-can be inherited seamlessly. We do have some users using Karmada in this way.
+Technically, `yes`. You can install Karmada in an existing Kubernetes cluster and reuse the
+`kube-apiserver` as the Karmada apiserver instead of deploying a standalone
+[karmada-apiserver](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/karmada-apiserver.yaml).
+In this setup, Karmada can also benefit from the high availability capabilities of the existing Kubernetes control plane.
 
-There are some things you should consider before doing so:
+However, this deployment mode is not generally recommended as the default choice. If you still decide to use it, please
+carefully evaluate the following considerations:
 
-- This approach hasn't been fully tested by the Karmada community and no plan for it yet.
-- This approach will increase computation costs for the Karmada system. E.g.
-  After you apply a `resource template`, take `Deployment` as an example, the `kube-controller` will create `Pods` for the
-  Deployment and update the status persistently, Karmada system will reconcile these changes too, so there might be
-  conflicts.
+- This approach has not been fully tested by the Karmada community, and there is no plan to make it a recommended
+  deployment mode at this time.
+- Reusing the Kubernetes `kube-apiserver` may increase the computational cost and reconciliation pressure on the Karmada
+  system. For example, after you apply a `resource template`, such as a `Deployment`, the `kube-controller-manager` may
+  create `Pods` for the `Deployment` and continuously update its status. Karmada controllers may also reconcile these
+  changes, which can lead to unexpected interactions or conflicts.
+- The Kubernetes control plane and the Karmada control plane will share the same API server, so operational issues,
+  configuration changes, or resource pressure in one system may affect the other.
 
-TODO: Link to adoption use case once it gets on board.
+In general, deploying a dedicated `karmada-apiserver` is preferred for clearer isolation and more predictable behavior.
+Reusing an existing `kube-apiserver` should be considered only when you fully understand the trade-offs and can accept the
+potential risks.
 
 ## Why Cluster API doesn't have the CRD YAML file?
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/faq/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/faq/faq.md
@@ -25,18 +25,21 @@ title: 常见问题
 
 ## 我可以在 Kubernetes 集群中安装 Karmada 并将 kube-apiserver 重用为 Karmada apiserver 吗？
 
-答案是 `yes`。在这种情况下，你可以在部署
-[karmada-apiserver](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/karmada-apiserver.yaml)
-时节省不少时间，只需在 Kubernetes 和 Karmada 之间共享 APIServer 即可。
-此外，这样可以无缝继承原集群的高可用能力。我们确实有一些用户以这种方式使用 Karmada。
+技术上来说，答案是 `yes`。你可以在现有 Kubernetes 集群中安装 Karmada，并复用
+`kube-apiserver` 作为 Karmada apiserver，而不是部署独立的
+[karmada-apiserver](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/karmada-apiserver.yaml)。
+在这种模式下，Karmada 也可以受益于现有 Kubernetes 控制平面的高可用能力。
 
-不过在此之前你需要注意以下几点：
+不过，通常不建议将这种部署模式作为默认选择。如果你仍决定使用，请仔细评估以下事项：
 
-- 这种方法尚未经过 Karmada 社区的全面测试，也没有相关测试计划。
-- 这种方法会增加 Karmada 系统的计算成本。
-  以 `Deployment` 为例采用 `resource template` 后，`kube-controller` 会为 Deployment 创建 `Pods` 并持续更新状态，Karmada 系统也会协调这些变化，所以可能会发生冲突。
+- 这种方法尚未经过 Karmada 社区的全面测试，目前也没有计划将其作为推荐的部署模式。
+- 复用 Kubernetes `kube-apiserver` 可能会增加 Karmada 系统的计算开销和调谐压力。
+  例如，在你应用 `resource template`（如 `Deployment`）后，`kube-controller-manager` 可能会为该 `Deployment` 创建 `Pods` 并持续更新其状态。
+  Karmada 控制器也可能会调谐这些变更，从而导致非预期的交互或冲突。
+- Kubernetes 控制平面和 Karmada 控制平面将共享同一个 API server，因此其中一个系统中的运维问题、配置变更或资源压力可能会影响另一个系统。
 
-待办事项：一旦有相关使用案例，我们将添加相应链接。
+一般来说，部署专用的 `karmada-apiserver` 更有利于实现清晰的隔离和更可预测的行为。
+只有在你充分理解相关权衡并能够接受潜在风险时，才应考虑复用现有的 `kube-apiserver`。
 
 ## 为什么 Cluster API 没有 CRD YAML 文件?
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This pull request updates the FAQ documentation in both English (`docs/faq/faq.md`) and Chinese (`i18n/zh/docusaurus-plugin-content-docs/current/faq/faq.md`) to clarify guidance around reusing the Kubernetes `kube-apiserver` as the Karmada apiserver. The new content provides a more nuanced explanation of the technical feasibility, associated risks, and recommendations for this deployment mode.

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/karmada/issues/3907

**Special notes for your reviewer**:


