### PR TITLE
docs - fixed configuration file priority over CLI flags in karmadactl…

### DIFF
--- a/docs/reference/karmadactl/karmadactl-config.v1alpha1.md
+++ b/docs/reference/karmadactl/karmadactl-config.v1alpha1.md
@@ -484,10 +484,12 @@ To use this configuration file with `karmadactl init`, simply pass the path to t
 karmadactl init --config /path/to/karmada-init.yaml
 ```
 
-### Overriding Configuration File Values
+### Configuration File Precedence
 
-If necessary, command line flags can still be used in conjunction with the configuration file. The parameters specified via the command line will override those in the configuration file. For example, to override the number of API server replicas, you could use:
+Command line flags can still be used together with the configuration file. However, when both specify the same parameter, the value from the configuration file takes precedence over the command line flag. For example, if you run:
 
 ```bash
 karmadactl init --config /path/to/karmada-init.yaml --karmada-apiserver-replicas 5
 ```
+
+and the configuration file sets components.karmadaAPIServer.replicas to 3, the final value will be 3 (from the config file), not 5.

--- a/versioned_docs/version-v1.13/reference/karmadactl/karmadactl-config.v1alpha1.md
+++ b/versioned_docs/version-v1.13/reference/karmadactl/karmadactl-config.v1alpha1.md
@@ -391,10 +391,12 @@ To use this configuration file with `karmadactl init`, simply pass the path to t
 karmadactl init --config /path/to/karmada-init.yaml
 ```
 
-### Overriding Configuration File Values
+### Configuration File Precedence
 
-If necessary, command-line flags can still be used in conjunction with the configuration file. The parameters specified via the command line will override those in the configuration file. For example, to override the number of API server replicas, you could use:
+Command-line flags can still be used together with the configuration file. However, when both specify the same parameter, the value from the configuration file takes precedence over the command-line flag. For example, if you run:
 
 ```bash
 karmadactl init --config /path/to/karmada-init.yaml --karmada-apiserver-replicas 5
 ```
+
+and the configuration file sets components.karmadaAPIServer.replicas to 3, the final value will be 3 (from the config file), not 5.

--- a/versioned_docs/version-v1.14/reference/karmadactl/karmadactl-config.v1alpha1.md
+++ b/versioned_docs/version-v1.14/reference/karmadactl/karmadactl-config.v1alpha1.md
@@ -391,10 +391,12 @@ To use this configuration file with `karmadactl init`, simply pass the path to t
 karmadactl init --config /path/to/karmada-init.yaml
 ```
 
-### Overriding Configuration File Values
+### Configuration File Precedence
 
-If necessary, command-line flags can still be used in conjunction with the configuration file. The parameters specified via the command line will override those in the configuration file. For example, to override the number of API server replicas, you could use:
+Command-line flags can still be used together with the configuration file. However, when both specify the same parameter, the value from the configuration file takes precedence over the command-line flag. For example, if you run:
 
 ```bash
 karmadactl init --config /path/to/karmada-init.yaml --karmada-apiserver-replicas 5
 ```
+
+and the configuration file sets components.karmadaAPIServer.replicas to 3, the final value will be 3 (from the config file), not 5.

--- a/versioned_docs/version-v1.15/reference/karmadactl/karmadactl-config.v1alpha1.md
+++ b/versioned_docs/version-v1.15/reference/karmadactl/karmadactl-config.v1alpha1.md
@@ -391,10 +391,12 @@ To use this configuration file with `karmadactl init`, simply pass the path to t
 karmadactl init --config /path/to/karmada-init.yaml
 ```
 
-### Overriding Configuration File Values
+### Configuration File Precedence
 
-If necessary, command-line flags can still be used in conjunction with the configuration file. The parameters specified via the command line will override those in the configuration file. For example, to override the number of API server replicas, you could use:
+Command-line flags can still be used together with the configuration file. However, when both specify the same parameter, the value from the configuration file takes precedence over the command-line flag. For example, if you run:
 
 ```bash
 karmadactl init --config /path/to/karmada-init.yaml --karmada-apiserver-replicas 5
 ```
+
+and the configuration file sets components.karmadaAPIServer.replicas to 3, the final value will be 3 (from the config file), not 5.

--- a/versioned_docs/version-v1.16/reference/karmadactl/karmadactl-config.v1alpha1.md
+++ b/versioned_docs/version-v1.16/reference/karmadactl/karmadactl-config.v1alpha1.md
@@ -484,10 +484,12 @@ To use this configuration file with `karmadactl init`, simply pass the path to t
 karmadactl init --config /path/to/karmada-init.yaml
 ```
 
-### Overriding Configuration File Values
+### Configuration File Precedence
 
-If necessary, command line flags can still be used in conjunction with the configuration file. The parameters specified via the command line will override those in the configuration file. For example, to override the number of API server replicas, you could use:
+Command line flags can still be used together with the configuration file. However, when both specify the same parameter, the value from the configuration file takes precedence over the command line flag. For example, if you run:
 
 ```bash
 karmadactl init --config /path/to/karmada-init.yaml --karmada-apiserver-replicas 5
 ```
+
+and the configuration file sets components.karmadaAPIServer.replicas to 3, the final value will be 3 (from the config file), not 5.

--- a/versioned_docs/version-v1.17/reference/karmadactl/karmadactl-config.v1alpha1.md
+++ b/versioned_docs/version-v1.17/reference/karmadactl/karmadactl-config.v1alpha1.md
@@ -484,10 +484,12 @@ To use this configuration file with `karmadactl init`, simply pass the path to t
 karmadactl init --config /path/to/karmada-init.yaml
 ```
 
-### Overriding Configuration File Values
+### Configuration File Precedence
 
-If necessary, command line flags can still be used in conjunction with the configuration file. The parameters specified via the command line will override those in the configuration file. For example, to override the number of API server replicas, you could use:
+Command line flags can still be used together with the configuration file. However, when both specify the same parameter, the value from the configuration file takes precedence over the command line flag. For example, if you run:
 
 ```bash
 karmadactl init --config /path/to/karmada-init.yaml --karmada-apiserver-replicas 5
 ```
+
+and the configuration file sets components.karmadaAPIServer.replicas to 3, the final value will be 3 (from the config file), not 5.

--- a/versioned_docs/version-v1.18/reference/karmadactl/karmadactl-config.v1alpha1.md
+++ b/versioned_docs/version-v1.18/reference/karmadactl/karmadactl-config.v1alpha1.md
@@ -484,10 +484,12 @@ To use this configuration file with `karmadactl init`, simply pass the path to t
 karmadactl init --config /path/to/karmada-init.yaml
 ```
 
-### Overriding Configuration File Values
+### Configuration File Precedence
 
-If necessary, command line flags can still be used in conjunction with the configuration file. The parameters specified via the command line will override those in the configuration file. For example, to override the number of API server replicas, you could use:
+Command line flags can still be used together with the configuration file. However, when both specify the same parameter, the value from the configuration file takes precedence over the command line flag. For example, if you run:
 
 ```bash
 karmadactl init --config /path/to/karmada-init.yaml --karmada-apiserver-replicas 5
 ```
+
+and the configuration file sets components.karmadaAPIServer.replicas to 3, the final value will be 3 (from the config file), not 5.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Fixes a doc error for `karmadactl init`. The docs used to say that CLI flags override the config file, but it's actually the other way around (the config file wins). This updates the docs to match the actual code behavior and the original design proposal.

**Which issue(s) this PR fixes**:
Fixes #925

**Special notes for your reviewer**:
(You can just leave this blank or delete this line)
