### PR TITLE
docs: add v1.18 to v1.19 upgrading guide

### DIFF
--- a/docs/administrator/upgrading/v1.18-v1.19.md
+++ b/docs/administrator/upgrading/v1.18-v1.19.md
@@ -1,0 +1,27 @@
+---
+title: v1.18 to v1.19
+---
+
+Follow the [Regular Upgrading Process](./README.md).
+
+## Upgrading Notable Changes
+
+### API Changes
+
+- `Karmada API`: Introduced `spec.clusters[*].components` to both `ResourceBinding` and `ClusterResourceBinding` to represent per-component scheduling results for workloads with multiple pod templates. The scheduler populates this field when the `MultiplePodTemplatesScheduling` feature gate is enabled.
+- `Karmada API`: The deprecated `PurgeMode` values `Immediately` and `Graciously` have been removed. Use `Directly` and `Gracefully` instead.
+
+### Deprecation
+
+- `karmada-controller-manager`: The `recreate` label of the `create_resource_to_cluster` metric has been deprecated and will be removed in a future release.
+- `karmada-scheduler-estimator`: The deprecated proto message fields `ReplicaRequirements.resourceRequest`, `ComponentReplicaRequirements.resourceRequest`, `NodeClaim.nodeAffinity`, and `NodeClaim.tolerations` have been removed. Use `resourceRequestBytes`, `nodeAffinityBytes`, and `tolerationsBytes` as applicable.
+
+### Dependencies
+
+- Karmada is now built with Golang v1.26.7.
+- Kubernetes dependencies have been updated to v1.36.4 to address security concerns.
+- The base image `alpine` has been promoted from `alpine:3.23.4` to `alpine:3.24.0` to address security concerns.
+
+### Others
+
+- `karmada-scheduler`: Promoted the `PriorityBasedScheduling` feature gate to Beta and enabled it by default. Workloads now can be scheduled in priority order as declared via `spec.schedulePriority` in `PropagationPolicy`/`ClusterPropagationPolicy`. To opt out, set `--feature-gates=PriorityBasedScheduling=false`.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/administrator/upgrading/v1.18-v1.19.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/administrator/upgrading/v1.18-v1.19.md
@@ -1,0 +1,27 @@
+---
+title: v1.18 升级到 v1.19
+---
+
+遵循[常规升级流程](./README.md)。
+
+## 升级后显著变化
+
+### API 变化
+
+- `Karmada API`：在 `ResourceBinding` 和 `ClusterResourceBinding` 中新增 `spec.clusters[*].components` 字段，用于表示包含多个 Pod 模板的工作负载中各组件的调度结果。启用 `MultiplePodTemplatesScheduling` 特性门控后，调度器会填充该字段。
+- `Karmada API`：已移除弃用的 `PurgeMode` 值 `Immediately` 和 `Graciously`，请分别使用 `Directly` 和 `Gracefully`。
+
+### 弃用
+
+- `karmada-controller-manager`：`create_resource_to_cluster` 指标的 `recreate` 标签已弃用，并将在未来版本中移除。
+- `karmada-scheduler-estimator`：已移除弃用的 proto 消息字段 `ReplicaRequirements.resourceRequest`、`ComponentReplicaRequirements.resourceRequest`、`NodeClaim.nodeAffinity` 和 `NodeClaim.tolerations`。请根据字段类型分别使用 `resourceRequestBytes`、`nodeAffinityBytes` 和 `tolerationsBytes`。
+
+### 依赖升级
+
+- Karmada 现在使用 Golang v1.26.7 构建。
+- 为解决安全问题，Kubernetes 依赖已升级至 v1.36.4。
+- 为解决安全问题，基础镜像 `alpine` 已从 `alpine:3.23.4` 升级至 `alpine:3.24.0`。
+
+### 其他
+
+- `karmada-scheduler`：`PriorityBasedScheduling` 特性门控已提升至 Beta 并默认启用。工作负载现在可以按照 `PropagationPolicy`/`ClusterPropagationPolicy` 中通过 `spec.schedulePriority` 声明的优先级顺序进行调度。如需禁用，请设置 `--feature-gates=PriorityBasedScheduling=false`。

--- a/sidebars.js
+++ b/sidebars.js
@@ -254,7 +254,8 @@ module.exports = {
                         "administrator/upgrading/v1.14-v1.15",
                         "administrator/upgrading/v1.15-v1.16",
                         "administrator/upgrading/v1.16-v1.17",
-                        "administrator/upgrading/v1.17-v1.18"
+                        "administrator/upgrading/v1.17-v1.18",
+                        "administrator/upgrading/v1.18-v1.19"
                     ],
                 },
                 {


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds the upgrading guide from Karmada v1.18 to v1.19 in both English and Chinese.

The guide documents notable API changes, removed deprecated fields, dependency upgrades, and Helm chart changes. It also adds the new guide to the documentation sidebar.

**Which issue(s) this PR fixes**:

Part of karmada-io/karmada#7869

**Special notes for your reviewer**:

The documented changes are based on `docs/CHANGELOG/CHANGELOG-1.19.md` in the Karmada repository.


